### PR TITLE
Enhance GoogleSQL syntax highlighting and SelectTargets rule

### DIFF
--- a/server/src/linter/parser.ts
+++ b/server/src/linter/parser.ts
@@ -188,7 +188,7 @@ export class ColumnAST implements AST {
 		this.source = findToken(matchedRule.tokens, "entity.name.alias.sql")?.value ?? null;
 		this.column = findToken(matchedRule.tokens, "entity.other.column.sql")?.value ?? null;
 		this.alias = findToken(matchedRule.tokens, "entity.name.tag")?.value ?? null;
-		this.lineNumber = matchedRule.tokens[0].lineNumber;
+		this.lineNumber = matchedRule.tokens.filter((token) => !token.scopes.includes('punctuation.whitespace.leading.sql') && !token.scopes.includes('punctuation.whitespace.trailing.sql') && !token.scopes.includes('punctuation.whitespace.sql'))[0].lineNumber;
 		this.startIndex = matchedRule.tokens[0].startIndex;
 		this.endIndex = matchedRule.tokens[matchedRule.tokens.length - 1].endIndex;
 	}
@@ -226,7 +226,7 @@ class StringAST implements AST {
 		this.tokens = tokens;
 		this.value = tokens.map((token) => token.value).join('');
 		this.alias = findToken(tokens, "entity.name.tag")?.value ?? null;
-		this.lineNumber = tokens[0].lineNumber;
+		this.lineNumber = tokens.filter((token) => !token.scopes.includes('punctuation.whitespace.leading.sql') && !token.scopes.includes('punctuation.whitespace.trailing.sql') && !token.scopes.includes('punctuation.whitespace.sql'))[0].lineNumber;
 		this.startIndex = tokens[0].startIndex;
 		this.endIndex = tokens[tokens.length - 1].endIndex;
 	}
@@ -244,7 +244,7 @@ class NumberAST implements AST {
 		this.tokens = tokens;
 		this.value = Number(tokens.map((token) => token.value).join(''));
 		this.alias = findToken(tokens, "entity.name.tag")?.value ?? null;
-		this.lineNumber = tokens[0].lineNumber;
+		this.lineNumber = tokens.filter((token) => !token.scopes.includes('punctuation.whitespace.leading.sql') && !token.scopes.includes('punctuation.whitespace.trailing.sql') && !token.scopes.includes('punctuation.whitespace.sql'))[0].lineNumber;
 		this.startIndex = tokens[0].startIndex;
 		this.endIndex = tokens[tokens.length - 1].endIndex;
 	}
@@ -262,7 +262,7 @@ class KeywordAST implements AST {
 		this.tokens = tokens;
 		this.value = tokens.map((token) => token.value).join('');
 		this.alias = findToken(tokens, "entity.name.tag")?.value ?? null;
-		this.lineNumber = tokens[0].lineNumber;
+		this.lineNumber = tokens.filter((token) => !token.scopes.includes('punctuation.whitespace.leading.sql') && !token.scopes.includes('punctuation.whitespace.trailing.sql') && !token.scopes.includes('punctuation.whitespace.sql'))[0].lineNumber;
 		this.startIndex = tokens[0].startIndex;
 		this.endIndex = tokens[tokens.length - 1].endIndex;
 	}
@@ -313,7 +313,7 @@ export class ColumnFunctionAST implements AST {
 	constructor(matchedRule: MatchedRule) {
 		this.function = matchedRule.tokens.filter((token) => token.scopes.includes("meta.function.sql"))[0].value;
 		this.tokens.push(...matchedRule.tokens);
-		this.lineNumber = matchedRule.tokens[0].lineNumber;
+		this.lineNumber = matchedRule.tokens.filter((token) => !token.scopes.includes('punctuation.whitespace.leading.sql') && !token.scopes.includes('punctuation.whitespace.trailing.sql') && !token.scopes.includes('punctuation.whitespace.sql'))[0].lineNumber;
 		this.startIndex = matchedRule.tokens[0].startIndex;
 
 		// Special rules have been created for columns being cast as a type - these need split into column
@@ -432,7 +432,7 @@ export class ComparisonAST implements AST {
 		this.operator = comparison.operator;
 		this.right = comparison.right;
 		this.logicalOperator = comparison.logicalOperator;
-		this.lineNumber = tokens[0].lineNumber;
+		this.lineNumber = tokens.filter((token) => !token.scopes.includes('punctuation.whitespace.leading.sql') && !token.scopes.includes('punctuation.whitespace.trailing.sql') && !token.scopes.includes('punctuation.whitespace.sql'))[0].lineNumber;
 		this.startIndex = tokens[0].startIndex;
 		this.endIndex = tokens[tokens.length - 1].endIndex;
 	}
@@ -600,7 +600,7 @@ class CaseStatementAST implements AST {
 	
 	constructor(matchedRule: MatchedRule) {
 		this.tokens = matchedRule.tokens;
-		this.lineNumber = matchedRule.tokens[0].lineNumber;
+		this.lineNumber = matchedRule.tokens.filter((token) => !token.scopes.includes('punctuation.whitespace.leading.sql') && !token.scopes.includes('punctuation.whitespace.trailing.sql') && !token.scopes.includes('punctuation.whitespace.sql'))[0].lineNumber;
 		this.startIndex = matchedRule.tokens[0].startIndex;
 		this.endIndex = matchedRule.tokens[matchedRule.tokens.length - 1].endIndex;
 
@@ -635,7 +635,7 @@ class JoinAST implements AST {
 	
 	constructor(matchedRule: MatchedRule) {
 		this.tokens.push(...matchedRule.tokens);
-		this.lineNumber = matchedRule.tokens[0].lineNumber;
+		this.lineNumber = matchedRule.tokens.filter((token) => !token.scopes.includes('punctuation.whitespace.leading.sql') && !token.scopes.includes('punctuation.whitespace.trailing.sql') && !token.scopes.includes('punctuation.whitespace.sql'))[0].lineNumber;
 		this.startIndex = matchedRule.tokens[0].startIndex;
 
 		this.join = findToken(matchedRule.tokens, "keyword.join.sql")?.value as JoinType;
@@ -1147,8 +1147,33 @@ export class Parser {
 		const tokenizedLines: GrammarTokenizeLineResult[] = [];
 
 		for (let i = 0; i < lines.length; i++) {
-			const line = lines[i];
-			tokenizedLines.push(grammar.tokenizeLine(line, null, i + lineNumber));
+			let line = lines[i];
+
+			const result = grammar.tokenizeLine(line, null, i + lineNumber);
+
+			if (result.stoppedEarly) {
+				const startIndex = result.tokens[result.tokens.length - 1].endIndex;
+				const endIndex = line.length;
+				line = line.substring(startIndex, endIndex);
+
+				while (line.length > 0) {
+					const newResult = grammar.tokenizeLine(line, null, i + lineNumber);
+					// create new tokens with correct start index
+					newResult.tokens.forEach((token) => {
+							const newToken = {
+								startIndex: token.startIndex + startIndex,
+								endIndex: token.endIndex + startIndex,
+								scopes: token.scopes,
+							};
+							result.tokens.push(newToken);
+						});
+					
+					line = line.substring(newResult.tokens[newResult.tokens.length - 1].endIndex);
+				}
+
+			}
+
+			tokenizedLines.push(result);
 		}
 
 		const lineTokens: LineToken[] = [];

--- a/server/src/linter/rules/layout/LT04.ts
+++ b/server/src/linter/rules/layout/LT04.ts
@@ -54,18 +54,16 @@ export class TrailingComma extends Rule<FileMap> {
 
     const errors: Diagnostic[] = [];
     for (const i in ast) {
-      for (const column of ast[i].columns) {
+
+      const columns = ast[i].columns;
+
+      for (const column of columns) {
         const filteredTokens = column.tokens.filter((token) => !token.scopes.includes("punctuation.whitespace.leading.sql"));
+        
         if ((filteredTokens[0].value ?? '') === ',') {
           errors.push(this.createDiagnostic({
             start: { line: filteredTokens[0].lineNumber ?? 0, character: filteredTokens[0].startIndex ?? 0 },
             end: { line: filteredTokens[0].lineNumber ?? 0, character: filteredTokens[0].endIndex ?? 0 }
-          }, documentUri));
-        } else if ((filteredTokens.find((token) => token.value === ',')?.lineNumber ?? 0) > (filteredTokens[0].lineNumber ?? 0)) {
-          const commaToken = filteredTokens.find((token) => token.value === ',');
-          errors.push(this.createDiagnostic({
-            start: { line: commaToken?.lineNumber ?? 0, character: commaToken?.startIndex ?? 0 },
-            end: { line: commaToken?.lineNumber ?? 0, character: commaToken?.endIndex ?? 0 }
           }, documentUri));
         }
       }

--- a/server/src/linter/rules/layout/LT04.ts
+++ b/server/src/linter/rules/layout/LT04.ts
@@ -59,11 +59,27 @@ export class TrailingComma extends Rule<FileMap> {
 
       for (const column of columns) {
         const filteredTokens = column.tokens.filter((token) => !token.scopes.includes("punctuation.whitespace.leading.sql"));
+
+        // sort the tokens by linenumber then start index
+        filteredTokens.sort((a, b) => {
+          if (a.lineNumber === b.lineNumber) {
+            return a.startIndex - b.startIndex;
+          }
+          return a.lineNumber! - b.lineNumber!;
+        });
+
+        const firstToken = filteredTokens[0];
+        const lastToken = filteredTokens[filteredTokens.length - 1];
         
-        if ((filteredTokens[0].value ?? '') === ',') {
+        if ((firstToken.value ?? '') === ',' && lastToken.lineNumber! === firstToken.lineNumber!) {
           errors.push(this.createDiagnostic({
-            start: { line: filteredTokens[0].lineNumber ?? 0, character: filteredTokens[0].startIndex ?? 0 },
-            end: { line: filteredTokens[0].lineNumber ?? 0, character: filteredTokens[0].endIndex ?? 0 }
+            start: { line: firstToken.lineNumber ?? 0, character: firstToken.startIndex ?? 0 },
+            end: { line: firstToken.lineNumber ?? 0, character: firstToken.endIndex ?? 0 }
+          }, documentUri));
+        } else if (lastToken.value === ',' && lastToken.lineNumber! !== firstToken.lineNumber!) {
+          errors.push(this.createDiagnostic({
+            start: { line: lastToken.lineNumber ?? 0, character: lastToken.startIndex ?? 0 },
+            end: { line: lastToken.lineNumber ?? 0, character: lastToken.endIndex ?? 0 }
           }, documentUri));
         }
       }

--- a/server/src/linter/rules/layout/LT09.ts
+++ b/server/src/linter/rules/layout/LT09.ts
@@ -1,0 +1,72 @@
+
+import { ServerSettings } from "../../../settings";
+import { RuleType } from '../enums';
+import {
+  Diagnostic,
+} from 'vscode-languageserver/node';
+import { Rule } from '../base';
+import { FileMap } from '../../parser';
+
+
+/**
+ * The SelectTargets rule
+ * @class SelectTargets
+ * @extends Rule
+ * @memberof Linter.Rules
+ */
+export class SelectTargets extends Rule<FileMap> {
+  readonly name: string = "select_targets";
+  readonly code: string = "LT09";
+  readonly type: RuleType = RuleType.PARSER;
+  readonly message: string = "Select targets should be on separate lines.";
+
+  /**
+   * Creates an instance of SelectTargets.
+   * @param {ServerSettings} settings The server settings
+   * @param {number} problems The number of problems identified in the source code
+   * @memberof SelectTargets
+   */
+  constructor(settings: ServerSettings, problems: number) {
+    super(settings, problems);
+  }
+
+  /**
+   * Evaluates the provided Abstract Syntax Tree (AST) to identify and return diagnostics for layout issues.
+   * Specifically, it checks for misplaced commas in the SQL code represented by the AST.
+   *
+   * @param ast - The Abstract Syntax Tree (AST) representing the SQL code to be evaluated.
+   * @param documentUri - The URI of the document being evaluated. This parameter is optional and defaults to null.
+   * @returns An array of `Diagnostic` objects representing the layout issues found, or null if no issues are found or the rule is disabled.
+   */
+  evaluate(ast: FileMap, documentUri: string | null = null): Diagnostic[] | null {
+
+    if (this.enabled === false) {
+      return null;
+    }
+
+    const errors: Diagnostic[] = [];
+    for (const i in ast) {
+
+      const columns = ast[i].columns;
+
+      for (let j = 0; j < columns.length - 1; j ++) {
+        const current = columns[j];
+        const next = columns[j + 1]; 
+        if (current.lineNumber === next.lineNumber) {
+          errors.push(this.createDiagnostic({
+            start: {
+              line: current.lineNumber??0,
+              character: current.startIndex??0
+            },
+            end: {
+              line: next.lineNumber??0,
+              character: next.endIndex??0
+            }
+          }, documentUri));
+        }
+      }
+    }
+
+    return errors.length > 0 ? errors : null;
+  }
+}

--- a/server/src/linter/rules/layout/LT09.ts
+++ b/server/src/linter/rules/layout/LT09.ts
@@ -5,7 +5,7 @@ import {
   Diagnostic,
 } from 'vscode-languageserver/node';
 import { Rule } from '../base';
-import { FileMap } from '../../parser';
+import { ColumnAST, FileMap } from '../../parser';
 
 
 /**
@@ -52,7 +52,7 @@ export class SelectTargets extends Rule<FileMap> {
       for (let j = 0; j < columns.length - 1; j ++) {
         const current = columns[j];
         const next = columns[j + 1]; 
-        if (current.lineNumber === next.lineNumber) {
+        if (current.lineNumber === next.lineNumber  && current instanceof ColumnAST && next instanceof ColumnAST) {
           errors.push(this.createDiagnostic({
             start: {
               line: current.lineNumber??0,

--- a/server/src/linter/rules/layout/rules.ts
+++ b/server/src/linter/rules/layout/rules.ts
@@ -11,6 +11,7 @@ import { ServerSettings } from '../../../settings';
 import { TrailingSpaces } from './LT01';
 import { TrailingComma } from './LT04';
 import { Functions } from './LT06';
+import { SelectTargets } from './LT09';
 import { SelectModifiers } from './LT10';
 import { UnionCheck } from './LT11';
 import { EndofFile } from './LT12';
@@ -18,6 +19,7 @@ import { StartOfFile } from './LT13';
 import { FileMap } from '../../parser';
 
 export const classes = [SelectModifiers,
+												SelectTargets,
                         UnionCheck,
 												TrailingComma,
                         EndofFile,

--- a/server/src/linter/syntaxes/googlesql.tmLanguage.json
+++ b/server/src/linter/syntaxes/googlesql.tmLanguage.json
@@ -781,7 +781,7 @@
           "captures": {
             "1": { "name": "entity.other.column.sql" }
           },
-          "match": "(?i)^[ \\t,]*?([\\w_]+)(?=[ \\t]*?,|\\n|from)",
+          "match": "(?i)^[ \\t]*?([\\w_]+)(?=[ \\t]*?,|\\n|from)",
           "name": "meta.column.sql"
         },
         {

--- a/server/src/linter/syntaxes/googlesql.tmLanguage.json
+++ b/server/src/linter/syntaxes/googlesql.tmLanguage.json
@@ -315,7 +315,7 @@
         },
         {
           "captures": { "1": { "name": "support.function.aggregate.sql" } },
-          "match": "(?i)\\b(AVG|COUNT|MIN|MAX|SUM|ANY_VALUE|ARRAY_AGG|ARRAY_CONCAT_AGG|BIT_AND|BIT_OR|BIT_XOR|COUNTIF|LOGICAL_AND|LOGICAL_OR|STRING_AGG|CORR|COVAR_POP|COVAR_SAMP|STDDEV_POP|STDDEV_SAMP|STDDEV|VAR_POP|VAR_SAMP|VARIANCE|APPROX_COUNT_DISTINCT|APPROX_QUANTILES|APPROX_TOP_COUNT|APPROX_TOP_SUM|HLL_COUNT\\.\\w+)(?=\\s*\\()",
+          "match": "(?i)\\b(AVG|COUNT|MIN|MAX|SUM|ANY_VALUE|ARRAY_AGG|ARRAY_CONCAT_AGG|BIT_AND|BIT_OR|BIT_XOR|COUNTIF|LOGICAL_AND|LOGICAL_OR|STRING_AGG|CORR|COVAR_POP|COVAR_SAMP|STDDEV_POP|STDDEV_SAMP|STDDEV|VAR_POP|VAR_SAMP|VARIANCE|APPROX_COUNT_DISTINCT|APPROX_QUANTILES|APPROX_TOP_COUNT|APPROX_TOP_SUM|HLL_COUNT\\.[\\w_]+)(?=\\s*\\()",
           "name": "meta.function.sql"
         },
         {
@@ -371,7 +371,7 @@
         },
         {
           "captures": { "1": { "name": "support.function.debug.sql" } },
-          "match": "(?i)\\b(SAFE\\.\\w+)(?=\\s*\\()",
+          "match": "(?i)\\b(SAFE\\.[\\w_]+)(?=\\s*\\()",
           "name": "meta.function.sql"
         },
         {
@@ -459,7 +459,7 @@
             "8": { "name": "punctuation.definition.string.end.sql" },
             "9": { "name": "keyword.ddl.as.sql" }
           },
-          "match": "(?i:)^\\s*(create(?:\\s+or\\s+replace)?(?:\\s+temporary|\\s+temp)?|drop|alter)\\s+(schema|table(?:\\s+function)?|view|materialized\\s+view|(?:external|snapshot)\\s+table|model|function|procedure|column)\\b(?:\\s+(if(?:\\s+not)?\\s+exists)\\b)?(?:\\s+(`?)(?:(\\w+)\\.)?(?:(\\w+)\\.(\\w+)(`?)))(?:\\s+(as))?",
+          "match": "(?i:)^\\s*(create(?:\\s+or\\s+replace)?(?:\\s+temporary|\\s+temp)?|drop|alter)\\s+(schema|table(?:\\s+function)?|view|materialized\\s+view|(?:external|snapshot)\\s+table|model|function|procedure|column)\\b(?:\\s+(if(?:\\s+not)?\\s+exists)\\b)?(?:\\s+(`?)(?:([\\w_]+)\\.)?(?:([\\w_]+)\\.([\\w_]+)(`?)))(?:\\s+(as))?",
           "name": "meta.ddl.sql"
         },
         {
@@ -483,7 +483,7 @@
             "6": { "name": "entity.name.alias.sql" },
             "7": { "name": "punctuation.definition.string.end.sql" }
           },
-          "match": "(?i)^\\b((?:insert|merge)(?:\\s+into)?|truncate\\s+table|update|delete\\s+from|delete(?!\\s+from))(?:\\s+(`)?(?:(\\w+)\\.)?(?:(?>(\\w+)\\.(\\w+)|(?<!\\.)(\\w+))(`)?))",
+          "match": "(?i)^\\b((?:insert|merge)(?:\\s+into)?|truncate\\s+table|update|delete\\s+from|delete(?!\\s+from))(?:\\s+(`)?(?:([\\w_]+)\\.)?(?:(?>([\\w_]+)\\.([\\w_]+)|(?<!\\.)([\\w_]+))(`)?))",
           "name": "meta.dml.sql"
         },
         {
@@ -516,7 +516,7 @@
             "8": { "name": "keyword.as.sql" },
             "9": { "name": "entity.name.alias.sql" }
           },
-          "match": "(?i)(?:(from)|((?:(?:(?:inner|cross|(?:left|right|full)(?:\\s+outer)?)\\s+)join)))(?:\\s+(`?)(?:(\\w+)\\.)?(?:(\\w+)\\.(\\w+))(`?)(?:\\s+(?:(as)\\s+)?(\\w+))?)",
+          "match": "(?i)(?:(from)|((?:(?:(?:inner|cross|(?:left|right|full)(?:\\s+outer)?)\\s+)join)))(?:\\s+(`?)(?:([\\w_]+)\\.)?(?:([\\w_]+)\\.([\\w_]+))(`?)(?:\\s+(?:(as)\\s+)?([\\w_]+))?)",
           "name": "meta.source.sql"
         },
         {
@@ -755,7 +755,7 @@
             "4": { "name": "keyword.as.sql" },
             "5": { "name": "entity.name.tag" }
           },
-          "match": "(?i)(\\w+)(\\.)(\\w+)[ \t]+(as)[ \t]+(\\w+)(?:[ \t]*?,|\\n|from)",
+          "match": "(?i)([\\w_]+)(\\.)([\\w_]+)[ \\t]+(as)[ \\t]+([\\w_]+)(?:[ \\t]*?,|\\n|from)",
           "name": "meta.column.explicit.alias.sql"
         },
         {
@@ -765,7 +765,7 @@
             "3": { "name": "entity.other.column.sql" },
             "4": { "name": "entity.name.tag" }
           },
-          "match": "(?i)(\\w+)(\\.)(\\w+)[ \t]+(?:(?>as|(\\w+)))(?:[ \t]*?,|\\n|from)",
+          "match": "(?i)([\\w_]+)(\\.)([\\w_]+)[ \\t]+(?:(?>as|([\\w_]+)))(?:[ \\t]*?,|\\n|from)",
           "name": "meta.column.implicit.alias.sql"
         },
         {
@@ -774,22 +774,36 @@
             "2": { "name": "punctuation.separator.period.sql" },
             "3": { "name": "entity.other.column.sql" }
           },
-          "match": "(?i)(\\w+)(\\.)(\\w+)",
+          "match": "(?i)([\\w_]+)(\\.)([\\w_]+)",
           "name": "meta.column.no.alias.sql"
+        },
+        {
+          "captures": {
+            "1": { "name": "entity.other.column.sql" }
+          },
+          "match": "(?i)^[ \\t,]*?([\\w_]+)(?:[ \\t]*?,|\\n|from)",
+          "name": "meta.column.sql"
+        },
+        {
+          "captures": {
+            "1": { "name": "entity.other.column.sql" }
+          },
+          "match": "(?i)(?<=select )([\\w_]+)(?:[ \\t]*?,|\\n|from)",
+          "name": "meta.column.sql"
         },
         {
           "captures": {
             "1": { "name": "keyword.as.sql" },
             "2": { "name": "entity.name.tag" }
           },
-          "match": "(?i)(?:(as)[ \t]+)?(\\w+)(?:[ \t]*?,|\\n|from)",
+          "match": "(?i)(?:(as)[ \t]+)?([\\w_]+)(?:[ \\t]*?,|\\n|from)",
           "name": "meta.column.alias.sql"
         },
         {
           "captures": {
             "1": { "name": "entity.other.column.sql" }
           },
-          "match": "(?i)(\\w+)",
+          "match": "(?i)([\\w_]+)",
           "name": "meta.column.sql"
         }
       ]
@@ -802,7 +816,7 @@
             "2": { "name": "entity.name.object.sql" },
             "3": { "name": "keyword.dml.sql" }
           },
-          "match": "(?i)(?:(\\w+)\\.(\\w+)\\:(\\w+)\\:)",
+          "match": "(?i)(?:([\\w_]+)\\.([\\w_]+)\\:([\\w_]+)\\:)",
           "name": "meta.dml.sql"
         }
       ]
@@ -813,7 +827,7 @@
           "captures": {
             "1": { "name": "variable.parameter.sql" }
           },
-          "match": "(?i)(\\@\\b\\w+)\\b",
+          "match": "(?i)(\\@\\b[\\w_]+)\\b",
           "name": "meta.parameter.sql"
         }
       ]

--- a/server/src/linter/syntaxes/googlesql.tmLanguage.json
+++ b/server/src/linter/syntaxes/googlesql.tmLanguage.json
@@ -755,7 +755,7 @@
             "4": { "name": "keyword.as.sql" },
             "5": { "name": "entity.name.tag" }
           },
-          "match": "(?i)(\\w+)(\\.)(\\w+) +(as) +(\\w+)",
+          "match": "(?i)(\\w+)(\\.)(\\w+)[ \t]+(as)[ \t]+(\\w+)(?:[ \t]*?,|\\n|from)",
           "name": "meta.column.explicit.alias.sql"
         },
         {
@@ -765,7 +765,7 @@
             "3": { "name": "entity.other.column.sql" },
             "4": { "name": "entity.name.tag" }
           },
-          "match": "(?i)(\\w+)(\\.)(\\w+) +(?:(?>as|(\\w+)))(?: *?,|\\n|from)",
+          "match": "(?i)(\\w+)(\\.)(\\w+)[ \t]+(?:(?>as|(\\w+)))(?:[ \t]*?,|\\n|from)",
           "name": "meta.column.implicit.alias.sql"
         },
         {
@@ -782,7 +782,7 @@
             "1": { "name": "keyword.as.sql" },
             "2": { "name": "entity.name.tag" }
           },
-          "match": "(?i)(?:(as) +)?(\\w+)(?: *?,|\\n|from)",
+          "match": "(?i)(?:(as)[ \t]+)?(\\w+)(?:[ \t]*?,|\\n|from)",
           "name": "meta.column.alias.sql"
         },
         {

--- a/server/src/linter/syntaxes/googlesql.tmLanguage.json
+++ b/server/src/linter/syntaxes/googlesql.tmLanguage.json
@@ -755,14 +755,42 @@
             "4": { "name": "keyword.as.sql" },
             "5": { "name": "entity.name.tag" }
           },
-          "match": "(?i)(?:(?<!\\.)(?:(\\w+)(\\.))?(?>\\b\\d+\\b|((?:`)?\\w+(?:`)?))(?: +(?:(as) +)?(?!\\b(?:case|when|then|else|end|desc|asc|as|in|is|null|or|and|array|bool(?:ean)?|date(?:time)?|geography|(?:big)?numeric|(?:big)?decimal|float(?:64)?|(?:small|big|tiny|byte)?int(?:64|eger)?|record|string|time(?:stamp)?|struct)\\b)((?:`)?\\w+(?:`)?))?)",
-          "name": "meta.column.sql"
+          "match": "(?i)(\\w+)(\\.)(\\w+) +(as) +(\\w+)",
+          "name": "meta.column.explicit.alias.sql"
         },
         {
           "captures": {
-            "1": { "name": "entity.name.tag" }
+            "1": { "name": "entity.name.alias.sql" },
+            "2": { "name": "punctuation.separator.period.sql" },
+            "3": { "name": "entity.other.column.sql" },
+            "4": { "name": "entity.name.tag" }
           },
-          "match": "(?i)(?>^(?: *\\w+,? *$)|(?: +(?!\\b(?:case|when|then|else|end|desc|asc|as|in|is|null|or|and|array|bool(?:ean)?|date(?:time)?|geography|(?:big)?numeric|(?:big)?decimal|float(?:64)?|(?:small|big|tiny|byte)?int(?:64|eger)?|record|string|time(?:stamp)?|struct|distinct|\\d+)\\b)((?:`)?\\w+(?:`)?),? *$))"
+          "match": "(?i)(\\w+)(\\.)(\\w+) +(?:(?>as|(\\w+)))(?: *?,|\\n|from)",
+          "name": "meta.column.implicit.alias.sql"
+        },
+        {
+          "captures": {
+            "1": { "name": "entity.name.alias.sql" },
+            "2": { "name": "punctuation.separator.period.sql" },
+            "3": { "name": "entity.other.column.sql" }
+          },
+          "match": "(?i)(\\w+)(\\.)(\\w+)",
+          "name": "meta.column.no.alias.sql"
+        },
+        {
+          "captures": {
+            "1": { "name": "keyword.as.sql" },
+            "2": { "name": "entity.name.tag" }
+          },
+          "match": "(?i)(?:(as) +)?(\\w+)(?: *?,|\\n|from)",
+          "name": "meta.column.alias.sql"
+        },
+        {
+          "captures": {
+            "1": { "name": "entity.other.column.sql" }
+          },
+          "match": "(?i)(\\w+)",
+          "name": "meta.column.sql"
         }
       ]
     },

--- a/server/src/linter/syntaxes/googlesql.tmLanguage.json
+++ b/server/src/linter/syntaxes/googlesql.tmLanguage.json
@@ -755,7 +755,7 @@
             "4": { "name": "keyword.as.sql" },
             "5": { "name": "entity.name.tag" }
           },
-          "match": "(?i)([\\w_]+)(\\.)([\\w_]+)[ \\t]+(as)[ \\t]+([\\w_]+)(?:[ \\t]*?,|\\n|from)",
+          "match": "(?i)([\\w_]+)(\\.)([\\w_]+)[ \\t]+(as)[ \\t]+([\\w_]+)(?=[ \\t]*?,|\\n|from)",
           "name": "meta.column.explicit.alias.sql"
         },
         {
@@ -765,7 +765,7 @@
             "3": { "name": "entity.other.column.sql" },
             "4": { "name": "entity.name.tag" }
           },
-          "match": "(?i)([\\w_]+)(\\.)([\\w_]+)[ \\t]+(?:(?>as|([\\w_]+)))(?:[ \\t]*?,|\\n|from)",
+          "match": "(?i)([\\w_]+)(\\.)([\\w_]+)[ \\t]+(?:(?>as|([\\w_]+)))(?=[ \\t]*?,|\\n|from)",
           "name": "meta.column.implicit.alias.sql"
         },
         {
@@ -781,14 +781,21 @@
           "captures": {
             "1": { "name": "entity.other.column.sql" }
           },
-          "match": "(?i)^[ \\t,]*?([\\w_]+)(?:[ \\t]*?,|\\n|from)",
+          "match": "(?i)^[ \\t,]*?([\\w_]+)(?=[ \\t]*?,|\\n|from)",
           "name": "meta.column.sql"
         },
         {
           "captures": {
             "1": { "name": "entity.other.column.sql" }
           },
-          "match": "(?i)(?<=select )([\\w_]+)(?:[ \\t]*?,|\\n|from)",
+          "match": "(?i)(?<=select )([\\w_]+)(?=[ \\t]*?,|\\n|from)",
+          "name": "meta.column.sql"
+        },
+        {
+          "captures": {
+            "1": { "name": "entity.other.column.sql" }
+          },
+          "match": "(?i)(?<=,)[ \\t]*?(\\w+)(?=[ \\t]*?,|\\n|from)",
           "name": "meta.column.sql"
         },
         {
@@ -796,7 +803,7 @@
             "1": { "name": "keyword.as.sql" },
             "2": { "name": "entity.name.tag" }
           },
-          "match": "(?i)(?:(as)[ \t]+)?([\\w_]+)(?:[ \\t]*?,|\\n|from)",
+          "match": "(?i)(?:(as)[ \t]+)?([\\w_]+)(?=[ \\t]*?,|\\n|from)",
           "name": "meta.column.alias.sql"
         },
         {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -34,11 +34,9 @@ import { defaultSettings, ServerSettings } from './settings';
 // Also include all preview / proposed LSP features.
 
 const connection = createConnection(ProposedFeatures.all);
-connection.console.log('Server connection created');
 
 // Create a simple text document manager.
 const documents: TextDocuments<TextDocument> = new TextDocuments(TextDocument);
-connection.console.log('Server text document manager created');
 
 let hasConfigurationCapability = false;
 let hasWorkspaceFolderCapability = false;
@@ -46,7 +44,6 @@ let hasDiagnosticRelatedInformationCapability = false;
 
 connection.onInitialize((params: InitializeParams) => {
 	const capabilities = params.capabilities;
-	connection.console.log('Server initialized');
 
 	// Does the client support the `workspace/configuration` request?
 	// If not, we fall back using global settings.
@@ -88,18 +85,15 @@ connection.onInitialized(() => {
 	}
 	if (hasWorkspaceFolderCapability) {
 		connection.workspace.onDidChangeWorkspaceFolders(_event => {
-			connection.console.log('Workspace folder change event received.');
 		});
 	}
 });
 
 // The global settings, used when the `workspace/configuration` request is not supported by the client.
 let globalSettings: ServerSettings = defaultSettings;
-connection.console.log('Server global settings created');
 
 // Cache the settings of all open documents
 const documentSettings: Map<string, Thenable<ServerSettings>> = new Map();
-connection.console.log('Server document settings cache created');
 
 connection.onDidChangeConfiguration(change => {
 	if (hasConfigurationCapability) {
@@ -203,8 +197,6 @@ connection.onCompletionResolve(
 // Make the text document manager listen on the connection
 // for open, change and close text document events
 documents.listen(connection);
-connection.console.log('Server text document manager listening');
 
 // Listen on the connection
 connection.listen();
-connection.console.log('Server listening');

--- a/server/src/tests/linter/rules/layout/LT09.test.ts
+++ b/server/src/tests/linter/rules/layout/LT09.test.ts
@@ -4,14 +4,14 @@
 
 import { expect } from 'chai';
 import { defaultSettings } from '../../../../settings';
-import { TrailingComma } from '../../../../linter/rules/layout/LT04';
+import { SelectTargets } from '../../../../linter/rules/layout/LT09';
 import { FileMap, StatementAST, Parser } from '../../../../linter/parser';
 
-describe('TrailingComma', () => {
-    let instance: TrailingComma;
+describe('SelectTargets', () => {
+    let instance: SelectTargets;
 
     beforeEach(() => {
-        instance = new TrailingComma(defaultSettings, 0);
+        instance = new SelectTargets(defaultSettings, 0);
     });
 
     it('should return null when rule is disabled', () => {
@@ -20,20 +20,20 @@ describe('TrailingComma', () => {
         expect(result).to.be.null;
     });
 
-    it('should return diagnostic when rule is enabled and comma is at start of line', async () => {
+    it('should return diagnostic when rule is enabled and single line select', async () => {
         instance.enabled = true;
 
 
         const parser = new Parser();
 
-        const result = instance.evaluate(await parser.parse('SELECT col1\n ,col2\n FROM table'));
+        const result = instance.evaluate(await parser.parse('SELECT col1, col2\n FROM table'));
         expect(result).to.deep.equal([{
             code: instance.code,
             message: instance.message,
             severity: instance.severity,
             range: {
-                start: { line: 1, character: 1 },
-                end: { line: 1, character: 2 }
+                start: { line: 0, character: 7 },
+                end: { line: 0, character: 17 }
             },
             source: instance.source()
         }]);

--- a/server/src/tests/linter/rules/layout/LT09.test.ts
+++ b/server/src/tests/linter/rules/layout/LT09.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @fileoverview Test suite for LT04 module
+ */
+
+import { expect } from 'chai';
+import { defaultSettings } from '../../../../settings';
+import { TrailingComma } from '../../../../linter/rules/layout/LT04';
+import { FileMap, StatementAST, Parser } from '../../../../linter/parser';
+
+describe('TrailingComma', () => {
+    let instance: TrailingComma;
+
+    beforeEach(() => {
+        instance = new TrailingComma(defaultSettings, 0);
+    });
+
+    it('should return null when rule is disabled', () => {
+        instance.enabled = false;
+        const result = instance.evaluate({1: new StatementAST()} as FileMap);
+        expect(result).to.be.null;
+    });
+
+    it('should return diagnostic when rule is enabled and comma is at start of line', async () => {
+        instance.enabled = true;
+
+
+        const parser = new Parser();
+
+        const result = instance.evaluate(await parser.parse('SELECT col1\n ,col2\n FROM table'));
+        expect(result).to.deep.equal([{
+            code: instance.code,
+            message: instance.message,
+            severity: instance.severity,
+            range: {
+                start: { line: 1, character: 1 },
+                end: { line: 1, character: 2 }
+            },
+            source: instance.source()
+        }]);
+    });
+
+    it('should return null when rule is enabled but pattern does not match', async () => {
+        instance.enabled = true;
+
+        const parser = new Parser();
+
+        const result = instance.evaluate(await parser.parse('SELECT col1,\n col2\n FROM table'));
+        expect(result).to.be.null;
+    });
+});


### PR DESCRIPTION
This pull request includes several enhancements to the GoogleSQL syntax highlighting and adds the SelectTargets rule.

The GoogleSQL syntax highlighting now supports explicit and implicit alias support, as well as explicit and implicit column aliases.

The SelectTargets rule has been added to enforce separate lines for select targets and to handle explicit and implicit column aliases.

Additionally, the line tokenization logic has been refactored to handle lines with incomplete tokens and improve the handling of lines with incomplete tokens.