### PR TITLE
Add new linter rule for ambiguous queries (CV08)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,10 @@
+---
+version: 
+
+sphinx:
+  configuration: docs/source/conf.py
+
+python:
+  version: 3.11
+  install:
+    - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
-
-# BigQuerySQLFormatter-extension
+# BigQuery SQL Formatter
 
 [![Lint Code Base](https://github.com/sean-conkie/BigQuerySQLFormatter-extension/actions/workflows/super-linter.yml/badge.svg)](https://github.com/sean-conkie/BigQuerySQLFormatter-extension/actions/workflows/super-linter.yml)
 [![CodeQL](https://github.com/sean-conkie/BigQuerySQLFormatter-extension/actions/workflows/codeql.yml/badge.svg)](https://github.com/sean-conkie/BigQuerySQLFormatter-extension/actions/workflows/codeql.yml)
 [![Node.js Test](https://github.com/sean-conkie/BigQuerySQLFormatter-extension/actions/workflows/node.js.yml/badge.svg)](https://github.com/sean-conkie/BigQuerySQLFormatter-extension/actions/workflows/node.js.yml)
 [![codecov](https://codecov.io/gh/sean-conkie/BigQuerySQLFormatter-extension/graph/badge.svg?token=ZOM3PNJ2SL)](https://codecov.io/gh/sean-conkie/BigQuerySQLFormatter-extension)
 
-VS Code extension providing BigQuery SQL syntax checking
+## VS Code extension providing BigQuery SQL syntax checking
+
+The BigQuery SQL Formatter extension for Visual Studio Code provides syntax checking and formatting for BigQuery SQL queries. This extension aims to enhance the development experience for users working with BigQuery by offering features such as:
+
+* Syntax Checking: Automatically checks the syntax of BigQuery SQL queries to ensure they are correct and conform to best practices.
+* Formatting: Provides tools to format SQL queries according to predefined styles, making the code more readable and maintainable.
+* Language Server Integration: Utilizes a language server to offer real-time feedback and suggestions as users write SQL queries.
+* Support for Multiple SQL Dialects: While aimed at BigQuery use, the extension supports various SQL dialects, including standard SQL and GoogleSQL, ensuring compatibility with different BigQuery environments.
+* Best Practices Enforcement: Encourages the use of best practices in SQL query writing, such as preferring LEFT JOIN over RIGHT JOIN for better readability and maintainability.
+
+This extension is particularly useful for developers and data analysts who frequently write and maintain BigQuery SQL queries, providing them with tools to improve code quality and productivity.

--- a/README.md
+++ b/README.md
@@ -7,12 +7,20 @@
 
 ## VS Code extension providing BigQuery SQL syntax checking
 
-The BigQuery SQL Formatter extension for Visual Studio Code provides syntax checking and formatting for BigQuery SQL queries. This extension aims to enhance the development experience for users working with BigQuery by offering features such as:
+The BigQuery SQL Formatter extension for Visual Studio Code provides syntax checking and formatting for BigQuery SQL
+queries. This extension aims to enhance the development experience for users working with BigQuery by offering features
+such as:
 
-* Syntax Checking: Automatically checks the syntax of BigQuery SQL queries to ensure they are correct and conform to best practices.
-* Formatting: Provides tools to format SQL queries according to predefined styles, making the code more readable and maintainable.
-* Language Server Integration: Utilizes a language server to offer real-time feedback and suggestions as users write SQL queries.
-* Support for Multiple SQL Dialects: While aimed at BigQuery use, the extension supports various SQL dialects, including standard SQL and GoogleSQL, ensuring compatibility with different BigQuery environments.
-* Best Practices Enforcement: Encourages the use of best practices in SQL query writing, such as preferring LEFT JOIN over RIGHT JOIN for better readability and maintainability.
+* Syntax Checking: Automatically checks the syntax of BigQuery SQL queries to ensure they are correct and conform to
+best practices.
+* Formatting: Provides tools to format SQL queries according to predefined styles, making the code more readable and
+maintainable.
+* Language Server Integration: Utilizes a language server to offer real-time feedback and suggestions as users write SQL
+queries.
+* Support for Multiple SQL Dialects: While aimed at BigQuery use, the extension supports various SQL dialects, including
+standard SQL and GoogleSQL, ensuring compatibility with different BigQuery environments.
+* Best Practices Enforcement: Encourages the use of best practices in SQL query writing, such as preferring LEFT JOIN
+over RIGHT JOIN for better readability and maintainability.
 
-This extension is particularly useful for developers and data analysts who frequently write and maintain BigQuery SQL queries, providing them with tools to improve code quality and productivity.
+This extension is particularly useful for developers and data analysts who frequently write and maintain BigQuery SQL
+queries, providing them with tools to improve code quality and productivity.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx==7.1.2
+sphinx-rtd-theme==1.3.0rc1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,35 @@
+# Configuration file for the Sphinx documentation builder.
+
+# -- Project information
+
+project = "BigQuery SQL Formatter"
+copyright = "2024, sean-conkie"
+author = "sean-conkie"
+
+release = "0.1"
+version = "0.0.5"
+
+# -- General configuration
+
+extensions = [
+    "sphinx.ext.duration",
+    "sphinx.ext.doctest",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.intersphinx",
+]
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3/", None),
+    "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
+}
+intersphinx_disabled_domains = ["std"]
+
+templates_path = ["_templates"]
+
+# -- Options for HTML output
+
+html_theme = "sphinx_rtd_theme"
+
+# -- Options for EPUB output
+epub_show_urls = "footnote"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,13 @@
+# BigQuery SQL Formatter
+
+## VS Code extension providing BigQuery SQL syntax checking
+
+The BigQuery SQL Formatter extension for Visual Studio Code provides syntax checking and formatting for BigQuery SQL queries. This extension aims to enhance the development experience for users working with BigQuery by offering features such as:
+
+* Syntax Checking: Automatically checks the syntax of BigQuery SQL queries to ensure they are correct and conform to best practices.
+* Formatting: Provides tools to format SQL queries according to predefined styles, making the code more readable and maintainable.
+* Language Server Integration: Utilizes a language server to offer real-time feedback and suggestions as users write SQL queries.
+* Support for Multiple SQL Dialects: While aimed at BigQuery use, the extension supports various SQL dialects, including standard SQL and GoogleSQL, ensuring compatibility with different BigQuery environments.
+* Best Practices Enforcement: Encourages the use of best practices in SQL query writing, such as preferring LEFT JOIN over RIGHT JOIN for better readability and maintainability.
+
+This extension is particularly useful for developers and data analysts who frequently write and maintain BigQuery SQL queries, providing them with tools to improve code quality and productivity.

--- a/docs/source/rules/convention/CV08.rst
+++ b/docs/source/rules/convention/CV08.rst
@@ -1,0 +1,59 @@
+# Rule: Use `LEFT JOIN` Instead of `RIGHT JOIN`
+
+### Rule Code: CV08
+### Name: `left_join`
+
+## Overview
+
+The SQL `JOIN` operations allow combining records from two or more tables based on a related column. There are various types of joins, such as `INNER JOIN`, `LEFT JOIN`, and `RIGHT JOIN`. While both `LEFT JOIN` and `RIGHT JOIN` can achieve the same results by reversing the table order, the **best practice** is to favor the use of `LEFT JOIN` over `RIGHT JOIN`.
+
+## Explanation
+
+### Anti-pattern: Using `RIGHT JOIN`
+
+The use of `RIGHT JOIN` in SQL is generally considered an anti-pattern for several reasons:
+- It reverses the typical left-to-right reading flow of SQL queries.
+- It can make queries less readable and harder to understand, especially in complex queries.
+- `RIGHT JOIN` requires the reader to mentally reverse the order of tables to comprehend the results.
+
+**Example of `RIGHT JOIN` usage (Anti-pattern):**
+```sql
+SELECT
+    foo.col1,
+    bar.col2
+FROM foo
+RIGHT JOIN bar
+    ON foo.bar_id = bar.id;
+```
+
+## Best Practice: Use `LEFT JOIN` Instead
+
+It is recommended to use `LEFT JOIN` because it:
+
+	•	Aligns with the natural left-to-right flow of reading and writing queries.
+	•	Enhances readability and consistency in SQL code.
+	•	Is more commonly used and understood in practice.
+
+**Refactored query using `LEFT JOIN` (Best practice):**
+```sql
+SELECT
+    foo.col1,
+    bar.col2
+FROM bar
+LEFT JOIN foo
+    ON foo.bar_id = bar.id;
+```
+
+### Benefits of LEFT JOIN:
+
+	•	The results and logic remain the same as RIGHT JOIN but in a more intuitive manner.
+	•	Promotes better maintainability and reduces confusion for other developers reviewing the code.
+
+## Conclusion
+
+While RIGHT JOIN and LEFT JOIN are functionally equivalent when the table order is reversed, it is a best practice to use LEFT JOIN for better readability, consistency, and maintainability in SQL queries.
+
+Groups:
+
+	•	all
+	•	convention

--- a/docs/source/rules/convention/index.rst
+++ b/docs/source/rules/convention/index.rst
@@ -1,0 +1,13 @@
+# Convention Rules
+
+Convention rules are guidelines that enforce consistent practices and coding patterns across a project. These rules aim to enhance readability, maintainability, and overall code quality by adhering to widely accepted best practices. They typically focus on the structure, style, and efficiency of code, helping developers avoid anti-patterns and ensure that the project follows uniform conventions.
+
+By applying convention rules, teams can create a more collaborative and coherent development environment where code is predictable, easier to review, and less error-prone.
+
+---
+
+
+.. toctree::
+	 :maxdepth: 1
+
+	 Rule: Use `LEFT JOIN` Instead of `RIGHT JOIN` <CV08>

--- a/server/src/linter/rules/base.ts
+++ b/server/src/linter/rules/base.ts
@@ -6,7 +6,7 @@
  * @requires RuleType
  */
 
-import { Diagnostic, DiagnosticSeverity, Range } from 'vscode-languageserver/node';
+import { Diagnostic, DiagnosticSeverity, DiagnosticTag, Range } from 'vscode-languageserver/node';
 import { RuleType } from './enums';
 import { ServerSettings } from '../../settings';
 import { FileMap } from '../parser';
@@ -27,6 +27,7 @@ export abstract class Rule<T extends string | FileMap>{
 	readonly message: string = "";
 	readonly relatedInformation: string = "";
 	readonly pattern: RegExp = /./;
+	readonly diagnosticTags: DiagnosticTag[] = [];
 	severity: DiagnosticSeverity = DiagnosticSeverity.Error;
 	enabled: boolean = true;
 	settings: ServerSettings;
@@ -115,11 +116,14 @@ export abstract class Rule<T extends string | FileMap>{
 				message: this.relatedInformation
 			}];
 		}
+		if (this.diagnosticTags.length > 0) {
+			diagnostic.tags = this.diagnosticTags;
+		}
 		return diagnostic;
 	}
 
 	source(): string {
-		return `${this.code} (${this.name})`;
+		return this.name;
 	}
 
 }

--- a/server/src/linter/rules/convention/CV08.ts
+++ b/server/src/linter/rules/convention/CV08.ts
@@ -1,30 +1,27 @@
 import { ServerSettings } from "../../../settings";
-import {
-  Diagnostic,
-  DiagnosticTag,
-} from 'vscode-languageserver/node';
+import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver/node';
 import { Rule } from '../base';
 
 
 /**
- * The ElseNull rule
- * @class ElseNull
+ * The LeftJoin rule
+ * @class LeftJoin
  * @extends Rule
  * @memberof Linter.Rules
  */
-export class ElseNull extends Rule<string> {
+export class LeftJoin extends Rule<string> {
   readonly name: string = "else_null";
-  readonly code: string = "ST01";
-  readonly message: string = "Omit `else null`.";
-	readonly relatedInformation: string = "Do not specify redundant `else null` in a case when statement.";
-  readonly pattern: RegExp = /else\s+null/gmi;
-  readonly diagnosticTags: DiagnosticTag[] = [DiagnosticTag.Unnecessary];
+  readonly code: string = "CV08";
+  readonly message: string = "Use LEFT JOIN instead of RIGHT JOIN.";
+	readonly relatedInformation: string = "It is recommended to avoid using RIGHT JOIN and instead use LEFT JOIN for consistency and readability, as it aligns with the natural left-to-right flow of reading SQL queries, making them easier to understand and maintain.";
+  readonly pattern: RegExp = /right\s+join/gmi;
+  readonly severity: DiagnosticSeverity = DiagnosticSeverity.Warning;
 
   /**
-   * Creates an instance of ElseNull.
+   * Creates an instance of LeftJoin.
    * @param {ServerSettings} settings The server settings
    * @param {number} problems The number of problems identified in the source code
-   * @memberof ElseNull
+   * @memberof LeftJoin
    */
   constructor(settings: ServerSettings, problems: number) {
     super(settings, problems);

--- a/server/src/linter/rules/convention/rules.ts
+++ b/server/src/linter/rules/convention/rules.ts
@@ -1,0 +1,26 @@
+/**
+ * @fileoverview Linter rules for layout
+ * @module linter/rules/layout
+ * @requires vscode-languageserver
+ * @requires settings
+ * @requires Rule
+ */
+
+import { Rule } from '../base';
+import { ServerSettings } from '../../../settings';
+import { LeftJoin } from './CV08';
+import { FileMap } from '../../parser';
+
+export const classes = [LeftJoin];
+
+export function conventionRules(settings: ServerSettings, problems: number): Rule<string | FileMap>[] {
+
+	const length: number = classes.length;
+	const rules: Rule<string | FileMap>[] = [];
+
+	for (let i = 0; i < length; i++) {
+		rules.push(new classes[i](settings, problems));
+	}
+
+	return rules;
+}

--- a/server/src/linter/rules/rules.ts
+++ b/server/src/linter/rules/rules.ts
@@ -2,6 +2,7 @@ import { ServerSettings } from '../../settings';
 import { aliasRules } from './aliasing/rules';
 import { ambiguousRules } from './ambiguous/rules';
 import { capitalisationRules } from './capitalisation/rules';
+import { conventionRules } from './convention/rules';
 import { layoutRules } from './layout/rules';
 import { structureRules } from './structure/rules';
 import { Rule } from './base';
@@ -21,6 +22,7 @@ export function initialiseRules(settings: ServerSettings, problems: number): Rul
 		...aliasRules(settings, problems),
 		...ambiguousRules(settings, problems),
 		...capitalisationRules(settings, problems),
+		...conventionRules(settings, problems),
 		...layoutRules(settings, problems),
 		...structureRules(settings, problems)
 	];

--- a/server/src/tests/linter/rules/convention/CV08.test.ts
+++ b/server/src/tests/linter/rules/convention/CV08.test.ts
@@ -4,13 +4,13 @@
 
 import { expect } from 'chai';
 import { defaultSettings } from '../../../../settings';
-import { StartOfFile } from '../../../../linter/rules/layout/LT13';
+import { LeftJoin } from '../../../../linter/rules/convention/CV08';
 
-describe('StartOfFile', () => {
-    let instance: StartOfFile;
+describe('LeftJoin', () => {
+    let instance: LeftJoin;
 
     beforeEach(() => {
-        instance = new StartOfFile(defaultSettings, 0);
+        instance = new LeftJoin(defaultSettings, 0);
     });
 
     it('should return null when rule is disabled', () => {
@@ -21,14 +21,14 @@ describe('StartOfFile', () => {
 
     it('should return diagnostic when rule is enabled and pattern matches', () => {
         instance.enabled = true;
-        const result = instance.evaluate(' select *\n  from table');
+        const result = instance.evaluate('select a.col, b.col from dataset.table a right join dataset.table b on a.col = b.col');
         expect(result).to.deep.equal([{
             code: instance.code,
             message: instance.message,
             severity: instance.severity,
             range: {
-                start: { line: 0, character: 0 },
-                end: { line: 0, character: 1 }
+                start: { line: 0, character: 41 },
+                end: { line: 0, character: 51 }
             },
             source: instance.source()
         }]);
@@ -36,7 +36,7 @@ describe('StartOfFile', () => {
 
     it('should return null when rule is enabled but pattern does not match', () => {
         instance.enabled = true;
-        const result = instance.evaluate('select *\n  from table');
+        const result = instance.evaluate('select a.col, b.col from dataset.table a left join dataset.table b on a.col = b.col');
         expect(result).to.be.null;
     });
 });

--- a/server/src/tests/linter/rules/convention/rules.test.ts
+++ b/server/src/tests/linter/rules/convention/rules.test.ts
@@ -1,0 +1,30 @@
+/**
+ * @fileoverview Test suite for layoutRules module
+ */
+
+import { expect } from 'chai';
+import { conventionRules } from '../../../../linter/rules/convention/rules';
+import { classes } from '../../../../linter/rules/convention/rules';
+import { defaultSettings } from '../../../../settings';
+
+describe('conventionRules', () => {
+    it('should return an array with a single instance of each rule', () => {
+        const problems = 0;
+        const result = conventionRules(defaultSettings, problems);
+        const classes_length = classes.length;
+        expect(result).to.be.an('array').that.has.lengthOf(classes_length);
+        for (const [index, val] of classes.entries()) {
+            expect(result[index]).to.be.an.instanceOf(val);
+        }
+    });
+
+    it('should pass the settings and problems to the each constructor', () => {
+        const problems = 5;
+        const result = conventionRules(defaultSettings, problems);
+        const length = result.length;
+        for (let i = 0; i < length; i++){
+            expect(result[i].settings).to.equal(defaultSettings);
+            expect(result[i].problems).to.equal(problems);
+        }
+    });
+});

--- a/server/src/tests/linter/rules/layout/LT01.test.ts
+++ b/server/src/tests/linter/rules/layout/LT01.test.ts
@@ -40,7 +40,7 @@ describe('TrailingSpaces', () => {
                     start: { line: parseInt(element[2]), character: parseInt(element[3]) },
                     end: { line: parseInt(element[4]), character: parseInt(element[5]) }
                 },
-                source: 'LT01 (trailing_sapces)'
+                source: instance.source()
             }]);
         });
     });
@@ -67,7 +67,7 @@ describe('TrailingSpaces', () => {
                         start: { line: parseInt(element[2]), character: parseInt(element[3]) },
                         end: { line: parseInt(element[4]), character: parseInt(element[5]) }
                     },
-                    source: 'LT01 (trailing_sapces)'
+                    source: instance.source()
                 },{
                     code: instance.code,
                     message: instance.message,
@@ -76,7 +76,7 @@ describe('TrailingSpaces', () => {
                         start: { line: parseInt(element[6]), character: parseInt(element[7]) },
                         end: { line: parseInt(element[8]), character: parseInt(element[9]) }
                     },
-                    source: 'LT01 (trailing_sapces)'
+                    source: instance.source()
                 }]);
             });
         });

--- a/server/src/tests/linter/rules/layout/LT10.test.ts
+++ b/server/src/tests/linter/rules/layout/LT10.test.ts
@@ -67,7 +67,7 @@ describe('SelectModifiers', () => {
                         start: { line: 0, character: 0 },
                         end: { line: expected_line, character: expected_character }
                     },
-                    source: 'LT10 (select_modifiers_check)'
+                    source: instance.source()
                 }]);
             });
         });

--- a/server/src/tests/linter/rules/layout/LT12.test.ts
+++ b/server/src/tests/linter/rules/layout/LT12.test.ts
@@ -30,7 +30,7 @@ describe('EndofFile', () => {
 								start: { line: 2, character: 12 },
 								end: { line: 2, character: 12 }
 						},
-						source: 'LT12 (end_of_file)'
+						source: instance.source()
 				}]);
 		});
 

--- a/server/src/tests/linter/rules/rules.test.ts
+++ b/server/src/tests/linter/rules/rules.test.ts
@@ -7,6 +7,7 @@ import { initialiseRules } from '../../../linter/rules/rules';
 import { aliasRules } from '../../../linter/rules/aliasing/rules';
 import { ambiguousRules } from '../../../linter/rules/ambiguous/rules';
 import { capitalisationRules } from '../../../linter/rules/capitalisation/rules';
+import { conventionRules } from '../../../linter/rules/convention/rules';
 import { layoutRules } from '../../../linter/rules/layout/rules';
 import { structureRules } from '../../../linter/rules/structure/rules';
 import { defaultSettings, ServerSettings } from '../../../settings'; // replace with your actual import
@@ -24,6 +25,7 @@ describe('initialiseRules', () => {
         const layoutRulesResult = [...aliasRules(settings, problems),
             ...ambiguousRules(settings, problems),
             ...capitalisationRules(settings, problems),
+            ...conventionRules(settings, problems),
             ...layoutRules(settings, problems),
             ...structureRules(settings, problems)];
         const result = initialiseRules(settings, problems);

--- a/server/src/tests/linter/rules/structure/ST01.test.ts
+++ b/server/src/tests/linter/rules/structure/ST01.test.ts
@@ -30,7 +30,8 @@ describe('ElseNull', () => {
                 start: { line: 0, character: 33 },
                 end: { line: 0, character: 42 }
             },
-            source: instance.source()
+            source: instance.source(),
+            tags: [1]
         }]);
     });
 


### PR DESCRIPTION
This pull request adds the Sphinx documentation structure and convention rules, along with the Read the Docs configuration and enhanced README with detailed extension features. It also includes a new linter rule for ambiguous queries (CV08). The changes ensure that the documentation is well-structured and follows best practices, and that the extension provides improved functionality and error checking for BigQuery SQL queries.