### PR TITLE
Add rule for checking unique column names (AL08)

### DIFF
--- a/docs/source/rules/aliasing/AL02.rst
+++ b/docs/source/rules/aliasing/AL02.rst
@@ -1,0 +1,54 @@
+===============================================================
+Rule: Do Not Use Explicit Aliasing (`AS`) When Aliasing Columns
+===============================================================
+
+**Rule Code:** ``AL02``
+
+**Name:** ``column``
+
+Overview
+--------
+
+In SQL, column aliasing is commonly used to rename the columns in the result set. While the `AS` keyword can be used for explicit aliasing, it is unnecessary when aliasing columns, as SQL supports implicit aliasing. Avoiding the use of `AS` when aliasing columns makes the query more concise without changing its meaning or functionality. This improves readability and aligns with common SQL practices.
+
+Explanation
+-----------
+
+Anti-pattern: Using `AS` for Column Aliasing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Using `AS` when aliasing columns adds unnecessary verbosity to the query. Although it is syntactically correct, it serves no additional purpose, as implicit aliasing works just as well. The explicit use of `AS` in column aliases can make queries longer and harder to read, especially when there are many columns being aliased.
+
+**Example of Using `AS` for Column Aliasing (Anti-pattern):**
+
+.. code-block:: sql
+
+    SELECT foo.id AS identifier, foo.name AS customer_name
+    FROM foo;
+
+In this example, the `AS` keyword is explicitly used to alias the `id` and `name` columns. While this is correct, the `AS` keyword is unnecessary and can be omitted for cleaner, more concise code.
+
+Best Practice: Use Implicit Aliasing for Columns (Without `AS`)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For better readability and concise code, column aliases should be defined without using the `AS` keyword. This removes redundancy and improves the overall clarity of the SQL statement without altering its functionality.
+
+**Refactored Example with Implicit Column Aliasing (Best Practice):**
+
+.. code-block:: sql
+
+    SELECT foo.id identifier, foo.name customer_name
+    FROM foo;
+
+In this refactored example, the `AS` keyword is omitted, and the aliases for `id` and `name` are defined implicitly. The query is cleaner and easier to read without sacrificing functionality.
+
+Conclusion
+----------
+
+Avoiding the explicit use of the `AS` keyword when aliasing columns leads to cleaner and more concise SQL queries. Implicit aliasing is fully supported in SQL and improves readability, making it the preferred choice when renaming columns in the result set.
+
+Groups:
+-------
+
+- `all <../..>`_
+- `aliasing <../..#aliasing-rules>`_

--- a/docs/source/rules/index.rst
+++ b/docs/source/rules/index.rst
@@ -16,6 +16,7 @@ Aliasing rules are guidelines that help developers avoid common pitfalls when us
 	:maxdepth: 1
 
 	Rule: Always Use Implicit Aliases When Referencing Tables <aliasing/AL01>
+	Rule: Do Not Use Explicit Aliasing (`AS`) When Aliasing Columns <aliasing/AL02>
 	Rule: Avoid Self-Aliasing Columns <aliasing/AL09>
 
 .. _ambiguous-rules:

--- a/server/src/linter/rules/aliasing/AL01.ts
+++ b/server/src/linter/rules/aliasing/AL01.ts
@@ -15,7 +15,6 @@ export class Table extends Rule<FileMap>{
   readonly code: string = "AL01";
   readonly message: string = "Explicit aliasing of tables.";
   readonly relatedInformation: string = "For better readability and cleaner code, implicit aliases should be used when referencing tables.";
-  readonly pattern: RegExp = / +$/gm;
 	readonly type: RuleType = RuleType.PARSER;
   readonly diagnosticTags: DiagnosticTag[] = [DiagnosticTag.Unnecessary];
   readonly ruleGroup: string = 'aliasing';

--- a/server/src/linter/rules/aliasing/AL02.ts
+++ b/server/src/linter/rules/aliasing/AL02.ts
@@ -15,7 +15,6 @@ export class ColumnAlias extends Rule<FileMap>{
   readonly code: string = "AL02";
   readonly message: string = "Explicit aliasing of columns.";
   readonly relatedInformation: string = "For better readability and cleaner code, implicit aliases should be used when referencing columns.";
-  readonly pattern: RegExp = / +$/gm;
 	readonly type: RuleType = RuleType.PARSER;
   readonly diagnosticTags: DiagnosticTag[] = [DiagnosticTag.Unnecessary];
   readonly ruleGroup: string = 'aliasing';

--- a/server/src/linter/rules/aliasing/AL08.ts
+++ b/server/src/linter/rules/aliasing/AL08.ts
@@ -1,0 +1,91 @@
+
+import { ServerSettings } from "../../../settings";
+import {
+  Diagnostic,
+  DiagnosticTag,
+  Range
+} from 'vscode-languageserver/node';
+import { RuleType } from '../enums';
+import { Rule } from '../base';
+import { FileMap } from '../../parser';
+import { ColumnAST } from '../../parser/ast';
+
+
+export class UniqueColumn extends Rule<FileMap>{
+  readonly name: string = "unique_column";
+  readonly code: string = "AL08";
+  readonly message: string = "Column names should be unique.";
+  readonly relatedInformation: string = "For better readability and cleaner code, implicit aliases should be used when referencing columns.";
+	readonly type: RuleType = RuleType.PARSER;
+  readonly diagnosticTags: DiagnosticTag[] = [DiagnosticTag.Unnecessary];
+  readonly ruleGroup: string = 'aliasing';
+
+  /**
+   * Creates an instance of UniqueColumn.
+   * @param {ServerSettings} settings The server settings
+   * @param {number} problems The number of problems identified in the source code
+   * @memberof UniqueColumn
+   */
+  constructor(settings: ServerSettings, problems: number) {
+      super(settings, problems);
+  }
+
+  /**
+   * Evaluates the given Abstract Syntax Tree (AST) to identify redundant aliases in column definitions.
+   * 
+   * @param ast - The Abstract Syntax Tree (AST) representing the SQL file structure.
+   * @param documentUri - The URI of the document being evaluated, or null if not applicable.
+   * @returns An array of Diagnostic objects representing the errors found, or null if no errors are found or the rule is disabled.
+   */
+  evaluate(ast: FileMap, documentUri: string | null = null): Diagnostic[] | null {
+
+    if (this.enabled === false) {
+      return null;
+    }
+		const errors: Diagnostic[] = [];
+    for (const i in ast) {
+
+			const columnsData: [string, Range][] = ast[i].columns.map((column) => {
+        let columnName: string | null = null;
+        const range = {
+          start: {
+            line: column.lineNumber ?? 0,
+            character: column.startIndex ?? 0,
+          },
+          end: {
+            line: column.lineNumber ?? 0,
+            character: column.endIndex ?? 0,
+          },
+        };
+      
+        if (column instanceof ColumnAST) {
+          columnName = column.alias == null ? column.column : column.alias;
+        } else {
+          columnName = column.alias == null ? 'f01' : column.alias;
+        }
+
+        if (columnName == null) {
+          columnName = 'f01';
+        }
+      
+        return [columnName, range];
+      });
+
+      // identify instances of duplicated column names and all the ranges where they appear
+      const duplicatedColumns: string[] = [];
+      columnsData.forEach((columnData, index) => {
+        const [columnName, range] = columnData;
+        const columnRanges = columnsData
+          .filter((cd) => cd[0] === columnName)
+          .map((cd) => cd[1]);
+        if (columnRanges.length > 1 && !duplicatedColumns.some((dc) => dc === columnName)) {
+          duplicatedColumns.push(columnName);
+          columnRanges.map(range => errors.push(this.createDiagnostic(range, documentUri)));
+        }
+      });
+
+    }
+
+    return errors.length > 0 ? errors : null;
+  }
+}

--- a/server/src/linter/rules/aliasing/rules.ts
+++ b/server/src/linter/rules/aliasing/rules.ts
@@ -3,10 +3,11 @@ import { Rule } from '../base';
 import { ServerSettings } from '../../../settings';
 import { Table } from './AL01';
 import { ColumnAlias } from './AL02';
+import { UniqueColumn } from './AL08';
 import { RedundantColumnAlias } from './AL09';
 import { FileMap } from '../../parser';
 
-export const classes = [Table, ColumnAlias, RedundantColumnAlias];
+export const classes = [Table, ColumnAlias, UniqueColumn, RedundantColumnAlias];
 
 /**
  * Generates an array of aliasing rules based on the provided settings and problems count.

--- a/server/src/linter/rules/layout/LT15.ts
+++ b/server/src/linter/rules/layout/LT15.ts
@@ -27,7 +27,7 @@ export class ComparisonOperators extends Rule<FileMap> {
   readonly name: string = "comparison_operators";
   readonly code: string = "LT15";
   readonly type: RuleType = RuleType.PARSER;
-  readonly message: string = "Align Equal (`=`) Sign in Comparison Blocks.";
+  readonly message: string = "Align equal sign in comparison blocks.";
   readonly relatedInformation: string = "When the equal (`=`) signs in a `WHERE` clause or join conditions are misaligned across multiple rows, it reduces the readability and consistency of the query.";
   readonly ruleGroup: string = 'layout';
 

--- a/server/src/tests/linter/rules/aliasing/AL08.test.ts
+++ b/server/src/tests/linter/rules/aliasing/AL08.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @fileoverview Test suite for AL08 module
+ */
+
+import { expect } from 'chai';
+import { defaultSettings } from '../../../../settings';
+import { UniqueColumn } from '../../../../linter/rules/aliasing/AL08';
+import { FileMap, Parser } from '../../../../linter/parser';
+import { StatementAST } from '../../../../linter/parser/ast';
+
+describe('UniqueColumn', () => {
+    let instance: UniqueColumn;
+
+    beforeEach(() => {
+        instance = new UniqueColumn(defaultSettings, 0);
+    });
+
+    it('should return null when rule is disabled', () => {
+        instance.enabled = false;
+        const result = instance.evaluate({1: new StatementAST()} as FileMap);
+        expect(result).to.be.null;
+    });
+
+    it('should return diagnostic when rule is enabled and as used', async () => {
+        instance.enabled = true;
+
+
+        const parser = new Parser();
+
+        const result = instance.evaluate(await parser.parse({text:'SELECT t.col1 as c\n       t.col2 as c\n FROM dataset.table t', uri: 'test.sql', languageId: 'sql', version: 0}));
+        expect(result).to.deep.equal([{
+            code: instance.diagnosticCode,
+            codeDescription: {href: instance.diagnosticCodeDescription},
+            message: instance.message,
+            severity: instance.severity,
+            range: {
+                start: { line: 0, character: 7 },
+                end: { line: 0, character: 18 }
+            },
+            source: instance.source,
+            tags: [1]
+        },
+        {
+            code: instance.diagnosticCode,
+            codeDescription: {href: instance.diagnosticCodeDescription},
+            message: instance.message,
+            severity: instance.severity,
+            range: {
+                start: { line: 1, character: 0 },
+                end: { line: 1, character: 18 }
+            },
+            source: instance.source,
+            tags: [1]
+        }]);
+    });
+
+    it('should return null when rule is enabled but pattern does not match', async () => {
+        instance.enabled = true;
+
+        const parser = new Parser();
+
+        const result = instance.evaluate(await parser.parse({text:'SELECT t.col1 as c\n       t.col2 as c2\n FROM dataset.table t', uri: 'test.sql', languageId: 'sql', version: 0}));
+        expect(result).to.be.null;
+    });
+});


### PR DESCRIPTION
This pull request adds two new rules to the codebase. The first rule, AL02, checks for explicit aliasing of columns and recommends using implicit aliases instead. The second rule, AL08, checks for duplicate column names and suggests making them unique. These rules improve the readability and maintainability of the codebase by enforcing best practices for column aliasing and naming.

<!-- readthedocs-preview bigquerysqlformatter start -->
----
📚 Documentation preview 📚: https://bigquerysqlformatter--194.org.readthedocs.build/en/194/

<!-- readthedocs-preview bigquerysqlformatter end -->