### PR TITLE
Add quick fixes support

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -104,7 +104,7 @@ then
 fi
 
 source .venv/bin/activate
-if ! pip instal -r ./docs/requirements.txt
+if ! pip install -r ./docs/requirements.txt
 then
     echo -e "${RED}Failed to install Sphinx.${RESET}"
     exit 1

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -88,6 +88,30 @@ fi
 echo -e "${GREEN}shellcheck installed.${RESET}"
 echo ""
 
+# add Sphinx
+echo -e "${BLUE}Installing Sphinx...${RESET}"
+
+if [[ -d .venv ]]
+then
+    echo -e "${YELLOW}Virtual environment already exists. Removing...${YELLOW}"
+    rm -rf .venv
+fi
+
+if ! python -m venv .venv
+then
+    echo -e "${RED}Failed to create virtual environment.${RESET}"
+    exit 1
+fi
+
+source .venv/bin/activate
+if ! pip instal -r ./docs/requirements.txt
+then
+    echo -e "${RED}Failed to install Sphinx.${RESET}"
+    exit 1
+fi
+echo -e "${GREEN}Sphinx installed.${RESET}"
+echo ""
+
 echo -e "${PURPLE}#########################################${RESET}"
 echo -e "${PURPLE}Setup complete!!${RESET}"
 echo -e "${PURPLE}#########################################${RESET}"

--- a/README.md
+++ b/README.md
@@ -24,3 +24,17 @@ over RIGHT JOIN for better readability and maintainability.
 
 This extension is particularly useful for developers and data analysts who frequently write and maintain BigQuery SQL
 queries, providing them with tools to improve code quality and productivity.
+
+## Configuration
+
+### Fix on save
+
+Add the following to your `settings.json`.
+
+```json
+  "[googlesql]": {
+    "editor.codeActionsOnSave": {
+      "source.fixAll": "explicit"
+    }
+  },
+```

--- a/docs/source/rules/aliasing/AL06.rst
+++ b/docs/source/rules/aliasing/AL06.rst
@@ -1,0 +1,56 @@
+=================================
+Rule: Tables Must Use an Alias
+=================================
+
+**Rule Code:** ``AL06``
+
+**Name:** ``table_alias``
+
+Overview
+--------
+
+In SQL queries, it is a best practice to always use table aliases, even if the query only involves a single table. Table aliases improve readability, especially in complex queries that involve multiple tables or self-joins. Aliasing tables simplifies the query and makes it easier to refer to the table columns, leading to better-maintained and more scalable code.
+
+Explanation
+-----------
+
+Anti-pattern: Not Using Aliases for Tables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When a query does not use table aliases, it forces the query to reference the full table name for each column. This can lead to cluttered and hard-to-read queries, especially when multiple tables or joins are involved. The lack of table aliases can also cause confusion when reading or maintaining the query, as it becomes harder to track which columns belong to which tables.
+
+**Example of a Query Without Table Aliases (Anti-pattern):**
+
+.. code-block:: sql
+
+    SELECT orders.id, orders.date, customers.name
+    FROM orders
+    JOIN customers ON orders.customer_id = customers.id;
+
+In this example, the full table names `orders` and `customers` are repeatedly referenced, making the query verbose and less readable.
+
+Best Practice: Always Use Table Aliases
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Using aliases for tables simplifies the query, improves readability, and makes it easier to reference table columns. Even if a query involves only one table, using an alias helps maintain consistency and scalability, especially when the query is extended to include additional tables.
+
+**Refactored Example with Table Aliases (Best Practice):**
+
+.. code-block:: sql
+
+    SELECT o.id, o.date, c.name
+    FROM orders o
+    JOIN customers c ON o.customer_id = c.id;
+
+In this refactored example, the tables `orders` and `customers` are given the aliases `o` and `c`, respectively. This makes the query more concise and easier to read, especially when the query becomes more complex.
+
+Conclusion
+----------
+
+Using table aliases in SQL queries is essential for improving readability, reducing verbosity, and maintaining clear and maintainable code. By following this rule and always using aliases for tables, developers can write cleaner, more efficient queries that are easier to scale and maintain.
+
+Groups:
+-------
+
+- `all <../..>`_
+- `aliasing <../..#aliasing-rules>`_

--- a/docs/source/rules/index.rst
+++ b/docs/source/rules/index.rst
@@ -18,6 +18,7 @@ Aliasing rules are guidelines that help developers avoid common pitfalls when us
 	Rule: Always Use Implicit Aliases When Referencing Tables <aliasing/AL01>
 	Rule: Do Not Use Explicit Aliasing (`AS`) When Aliasing Columns <aliasing/AL02>
 	Rule: All Columns Should Have a Table Alias <aliasing/AL05>
+	Rule: Tables Must Use an Alias <aliasing/AL06>
 	Rule: Column Names in the Query Should Be Unique <aliasing/AL08>
 	Rule: Avoid Self-Aliasing Columns <aliasing/AL09>
 

--- a/server/src/linter/linter.ts
+++ b/server/src/linter/linter.ts
@@ -1,5 +1,5 @@
 import { ServerSettings } from '../settings';
-import { Diagnostic, DidChangeTextDocumentParams, TextDocumentItem, CodeActionParams, CodeAction } from 'vscode-languageserver/node';
+import { Diagnostic, DidChangeTextDocumentParams, TextDocumentItem, CodeActionParams, CodeAction, CodeActionKind, Range, TextEdit } from 'vscode-languageserver/node';
 import { Rule } from './rules/base';
 import { initialiseRules } from './rules/rules';
 import { RuleType } from './rules/enums';
@@ -112,15 +112,65 @@ export class Linter {
 			this.regexRules.map((rule) => {if (rule.diagnosticCode === diagnostic.code && rule.is_fix_compatible) {
 				const action = rule.createCodeAction(params.textDocument, diagnostic);
 				if (action) {
-					codeActions.push(action);}
+					codeActions.push(...action);}
 			}});
 			this.parserRules.map((rule) => {if (rule.diagnosticCode === diagnostic.code && rule.is_fix_compatible) {
 				const action = rule.createCodeAction(params.textDocument, diagnostic);
 				if (action) {
-					codeActions.push(action);}
+					codeActions.push(...action);}
 			}});
 		});
-		return codeActions;
+
+
+		// split codeActions into two arrays `textEdits` where the code action is SourceFixAll and `quickFixes` where the code action is QuickFix
+		const textEdits: CodeAction[] = [];
+		const quickFixes: CodeAction[] = [];
+		codeActions.map((action) => {
+			if (action.kind === CodeActionKind.SourceFixAll) {
+				textEdits.push(action);
+			} else if (action.kind === CodeActionKind.QuickFix) {
+				quickFixes.push(action);
+			}
+		});
+
+		// Sort the TextEdits by their start positions in reverse order. This way, edits later in the document are applied first, preventing earlier
+		// edits from shifting the positions of later ones.
+		textEdits.sort((a, b) => {
+			const aStart = a.diagnostics![0].range.start;
+			const bStart = b.diagnostics![0].range.start;
+	
+			if (aStart.line !== bStart.line) {
+					return bStart.line - aStart.line;
+			}
+			return bStart.character - aStart.character;
+		});
+
+		// Remove overlapping edits
+		const nonOverlappingEdits: CodeAction[] = [];
+		let lastRange: Range | null = null;
+
+		for (const edit of textEdits) {
+				if (lastRange && this.areRangesOverlapping(edit.diagnostics![0].range, lastRange)) {
+						// Skip this edit or adjust the range
+						continue;
+				}
+				nonOverlappingEdits.push(edit);
+				lastRange = edit.diagnostics![0].range;
+		}
+
+		return [...nonOverlappingEdits, ...quickFixes];
 	}
+
+	private areRangesOverlapping(range1: Range, range2: Range): boolean {
+    const range1End = range1.end;
+    const range2Start = range2.start;
+
+    if (range1End.line < range2Start.line) return false;
+    if (range1End.line === range2Start.line && range1End.character <= range2Start.character)
+        return false;
+
+    return true;
+}
+
 
 }

--- a/server/src/linter/linter.ts
+++ b/server/src/linter/linter.ts
@@ -1,5 +1,5 @@
 import { ServerSettings } from '../settings';
-import { Diagnostic, DidChangeTextDocumentParams, TextDocumentItem } from 'vscode-languageserver/node';
+import { Diagnostic, DidChangeTextDocumentParams, TextDocumentItem, CodeActionParams, CodeAction } from 'vscode-languageserver/node';
 import { Rule } from './rules/base';
 import { initialiseRules } from './rules/rules';
 import { RuleType } from './rules/enums';
@@ -103,6 +103,24 @@ export class Linter {
 
 		return diagnostics;
 
+	}
+
+	async createCodeActions(params: CodeActionParams): Promise<CodeAction[]> {
+		const codeActions: CodeAction[] = [];
+
+		params.context.diagnostics.map((diagnostic) => {
+			this.regexRules.map((rule) => {if (rule.diagnosticCode === diagnostic.code && rule.is_fix_compatible) {
+				const action = rule.createCodeAction(params.textDocument, diagnostic);
+				if (action) {
+					codeActions.push(action);}
+			}});
+			this.parserRules.map((rule) => {if (rule.diagnosticCode === diagnostic.code && rule.is_fix_compatible) {
+				const action = rule.createCodeAction(params.textDocument, diagnostic);
+				if (action) {
+					codeActions.push(action);}
+			}});
+		});
+		return codeActions;
 	}
 
 }

--- a/server/src/linter/parser/index.ts
+++ b/server/src/linter/parser/index.ts
@@ -251,20 +251,43 @@ export class Parser {
 		}
 	}
 
+	/**
+	 * Processes a line replacement by updating the line with the new content.
+	 *
+	 * @param index - The index of the line to be replaced.
+	 * @param newLine - The new content for the line.
+	 * @param newLinesCount - The number of new lines to be added.
+	 * @param lineNumber - The current line number.
+	 * @param lineToken - The token representing the line.
+	 * @param change - The range of changes to be applied.
+	 * @returns A tuple containing the updated line number and the updated line token.
+	 */
 	private processLineReplace(index: number, newLine: string, newLinesCount: number, lineNumber: number, lineToken: LineToken, change: ChangedRange): [number, LineToken] {
 		return this.processLineUpdate(index, newLine, newLinesCount, lineNumber-index, lineToken, change);
 	}
+
+	/**
+	 * Processes an update to a line of text, adjusting the line number and token as necessary.
+	 *
+	 * @param index - The index of the line being updated relative to the change.
+	 * @param newLine - The new content of the line.
+	 * @param newLinesCount - The total number of new lines introduced by the change.
+	 * @param lineNumber - The original line number before the update.
+	 * @param lineToken - The token associated with the original line.
+	 * @param change - The range of the change within the line.
+	 * @returns A tuple containing the new line number and the updated line token.
+	 */
 	private processLineUpdate(index: number, newLine: string, newLinesCount: number, lineNumber: number, lineToken: LineToken, change: ChangedRange): [number, LineToken] {
 		const newLineNumber = lineNumber + index;
 		const retainedLinePrefix = index === 0 ? lineToken!.value.substring(0, change.startIndex) : '';
 		const retainedLineSuffix = index === (newLinesCount - 1) ? lineToken!.value.substring(change.endIndex) : '';
 		const value = retainedLinePrefix + newLine + retainedLineSuffix;
-		if (value !== lineToken?.value) {
+		if (value === lineToken?.value && lineToken?.lineNumber === newLineNumber) {
+			return [newLineNumber, lineToken!];
+		} else {
 			const ruleStack = lineToken === undefined ? null : lineToken.ruleStack;
 			const tokens = Parser.tokenize(this.grammar!, new Map([[newLineNumber, value]]), ruleStack);
 			return [newLineNumber, tokens[0]];
-		} else {
-			return [newLineNumber, lineToken!];
 		}
 	}
 

--- a/server/src/linter/parser/tokenCache.ts
+++ b/server/src/linter/parser/tokenCache.ts
@@ -1,5 +1,5 @@
 
-import { DocumentUri } from 'vscode-languageserver';
+import { DocumentUri, Range } from 'vscode-languageserver';
 import { LineToken } from './token';
 
 export const globalTokenCache: TokenCache = new Map<DocumentUri, DocumentCache>();
@@ -13,8 +13,26 @@ export class DocumentCache {
 		return this.cache.get(token);
 	}
 
-	public getText(): string {
+	public getText(range?: Range): string {
 		const lines: string[] = [];
+
+		if (range) {
+			const start = range.start.line;
+			const end = range.end.line;
+
+			for (let i = start; i <= end; i++) {
+				const lineToken = this.cache.get(i);
+				if (lineToken) {
+
+					const startIndex = range.start.line === i ? range.start.character : 0;
+					const endIndex = range.end.line === i ? range.end.character : lineToken.value.length;
+
+					lines.push(lineToken.value.substring(startIndex, endIndex));
+				}
+			}
+			return lines.join('\n');
+		}
+
 		this.cache.forEach((lineToken: LineToken) => lines.push(lineToken.value));
 		return lines.join('\n');
 	}

--- a/server/src/linter/rules/aliasing/AL01.ts
+++ b/server/src/linter/rules/aliasing/AL01.ts
@@ -25,6 +25,7 @@ export class Table extends Rule<FileMap>{
   readonly ruleGroup: string = 'aliasing';
 	readonly scope = 'keyword.as.sql';
   readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
+  readonly codeActionTitle = 'Remove explicit alias';
 
   /**
    * Creates an instance of Table.
@@ -130,12 +131,12 @@ export class Table extends Rule<FileMap>{
             ]
         }
     };
-    const title = 'Remove ambiguous DISTINCT clause';
+
     const actions: CodeAction[] = [];
     
     this.codeActionKind.map((kind) => {
       const fix = CodeAction.create(
-        title,
+        this.codeActionTitle,
         edit,
         kind
       );

--- a/server/src/linter/rules/aliasing/AL01.ts
+++ b/server/src/linter/rules/aliasing/AL01.ts
@@ -1,17 +1,21 @@
 
 import { ServerSettings } from "../../../settings";
 import {
+	CodeAction,
+  CodeActionKind,
   Diagnostic,
-  DiagnosticTag
+  DiagnosticTag,
+	TextDocumentIdentifier,
+	TextEdit
 } from 'vscode-languageserver/node';
 import { RuleType } from '../enums';
 import { Rule } from '../base';
 import { FileMap } from '../../parser';
 import { ObjectAST, StatementAST } from '../../parser/ast';
+import { globalTokenCache } from '../../parser/tokenCache';
 
 
 export class Table extends Rule<FileMap>{
-  readonly is_fix_compatible: boolean = false;
   readonly name: string = "table";
   readonly code: string = "AL01";
   readonly message: string = "Explicit aliasing of tables.";
@@ -20,6 +24,7 @@ export class Table extends Rule<FileMap>{
   readonly diagnosticTags: DiagnosticTag[] = [DiagnosticTag.Unnecessary];
   readonly ruleGroup: string = 'aliasing';
 	readonly scope = 'keyword.as.sql';
+  readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
 
   /**
    * Creates an instance of Table.
@@ -61,6 +66,13 @@ export class Table extends Rule<FileMap>{
     return errors.length > 0 ? errors : null;
   }
 
+	/**
+	 * Processes explicit aliasing in the given AST object and returns an array of diagnostics.
+	 *
+	 * @param object - The AST object to process, which can be either an ObjectAST or a StatementAST.
+	 * @param documentUri - The URI of the document being processed, or null if not applicable.
+	 * @returns An array of Diagnostic objects representing any issues found with explicit aliasing.
+	 */
 	private processExplicitAlias(object: ObjectAST | StatementAST, documentUri: string | null): Diagnostic[] {
 
 		const errors: Diagnostic[] = [];
@@ -85,4 +97,52 @@ export class Table extends Rule<FileMap>{
 		}
 		return errors;
 	}
+  
+  /**
+   * Creates a set of code actions to fix diagnostics.
+   *
+   * @param textDocument - The identifier of the text document where the diagnostic was reported.
+   * @param diagnostic - The diagnostic information about the issue to be fixed.
+   * @returns An array of code actions that can be applied to fix the issue.
+   */
+  createCodeAction(textDocument: TextDocumentIdentifier, diagnostic: Diagnostic): CodeAction[] {
+    const cachedDocument = globalTokenCache.get(textDocument.uri);
+    const extendedRange = {start: {line: diagnostic.range.start.line, character: diagnostic.range.start.character - 1}, end: {line: diagnostic.range.end.line, character: diagnostic.range.end.character + 1}};
+    const text = cachedDocument?.getText(extendedRange)??'';
+    let startOffset = 0;
+    let endOffset = 0;
+
+    if (/ as(?: |\n)/i.test(text)) {
+      // remove the starting space
+      startOffset = 1;
+    } else if (/as /i.test(text)) {
+      // remove the ending space
+      endOffset = 1;
+    }
+
+    diagnostic.range.start.character -= startOffset;
+    diagnostic.range.end.character += endOffset;
+
+    const edit = {
+        changes: {
+            [textDocument.uri]: [
+                TextEdit.replace(diagnostic.range, '')
+            ]
+        }
+    };
+    const title = 'Remove ambiguous DISTINCT clause';
+    const actions: CodeAction[] = [];
+    
+    this.codeActionKind.map((kind) => {
+      const fix = CodeAction.create(
+        title,
+        edit,
+        kind
+      );
+      fix.diagnostics = [diagnostic];
+      actions.push(fix);
+    });
+
+    return actions;
+  }
 }

--- a/server/src/linter/rules/aliasing/AL01.ts
+++ b/server/src/linter/rules/aliasing/AL01.ts
@@ -11,6 +11,7 @@ import { ObjectAST, StatementAST } from '../../parser/ast';
 
 
 export class Table extends Rule<FileMap>{
+  readonly is_fix_compatible: boolean = false;
   readonly name: string = "table";
   readonly code: string = "AL01";
   readonly message: string = "Explicit aliasing of tables.";

--- a/server/src/linter/rules/aliasing/AL02.ts
+++ b/server/src/linter/rules/aliasing/AL02.ts
@@ -1,17 +1,21 @@
 
 import { ServerSettings } from "../../../settings";
 import {
+  CodeAction,
+  CodeActionKind,
   Diagnostic,
-  DiagnosticTag
+  DiagnosticTag,
+  TextDocumentIdentifier,
+  TextEdit
 } from 'vscode-languageserver/node';
 import { RuleType } from '../enums';
 import { Rule } from '../base';
 import { FileMap } from '../../parser';
 import { excludeTokensWithMatchingScopes, includeTokensWithMatchingScopes } from '../../parser/token';
+import { globalTokenCache } from '../../parser/tokenCache';
 
 
 export class ColumnAlias extends Rule<FileMap>{
-  readonly is_fix_compatible: boolean = false;
   readonly name: string = "column";
   readonly code: string = "AL02";
   readonly message: string = "Explicit aliasing of columns.";
@@ -20,6 +24,7 @@ export class ColumnAlias extends Rule<FileMap>{
   readonly diagnosticTags: DiagnosticTag[] = [DiagnosticTag.Unnecessary];
   readonly ruleGroup: string = 'aliasing';
 	readonly scope = 'keyword.as.sql';
+  readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
 
   /**
    * Creates an instance of ColumnAlias.
@@ -79,5 +84,53 @@ export class ColumnAlias extends Rule<FileMap>{
     }
 
     return errors.length > 0 ? errors : null;
+  }
+  
+  /**
+   * Creates a set of code actions to fix diagnostics.
+   *
+   * @param textDocument - The identifier of the text document where the diagnostic was reported.
+   * @param diagnostic - The diagnostic information about the issue to be fixed.
+   * @returns An array of code actions that can be applied to fix the issue.
+   */
+  createCodeAction(textDocument: TextDocumentIdentifier, diagnostic: Diagnostic): CodeAction[] {
+    const cachedDocument = globalTokenCache.get(textDocument.uri);
+    const extendedRange = {start: {line: diagnostic.range.start.line, character: diagnostic.range.start.character - 1}, end: {line: diagnostic.range.end.line, character: diagnostic.range.end.character + 1}};
+    const text = cachedDocument?.getText(extendedRange)??'';
+    let startOffset = 0;
+    let endOffset = 0;
+
+    if (/ as(?: |\n)/i.test(text)) {
+      // remove the starting space
+      startOffset = 1;
+    } else if (/as /i.test(text)) {
+      // remove the ending space
+      endOffset = 1;
+    }
+
+    diagnostic.range.start.character -= startOffset;
+    diagnostic.range.end.character += endOffset;
+
+    const edit = {
+        changes: {
+            [textDocument.uri]: [
+                TextEdit.replace(diagnostic.range, '')
+            ]
+        }
+    };
+    const title = 'Remove ambiguous DISTINCT clause';
+    const actions: CodeAction[] = [];
+    
+    this.codeActionKind.map((kind) => {
+      const fix = CodeAction.create(
+        title,
+        edit,
+        kind
+      );
+      fix.diagnostics = [diagnostic];
+      actions.push(fix);
+    });
+
+    return actions;
   }
 }

--- a/server/src/linter/rules/aliasing/AL02.ts
+++ b/server/src/linter/rules/aliasing/AL02.ts
@@ -51,7 +51,17 @@ export class ColumnAlias extends Rule<FileMap>{
           const filteredTokesn = excludeTokensWithMatchingScopes(column.tokens, ['punctuation.whitespace.sql', 'punctuation.whitespace.leading.sql', 'punctuation.whitespace.trailing.sql']);
           // find an 'keyword.as.sql' token that is followed by a 'meta.column.alias.sql'
           const explicitAlias = filteredTokesn.find((token, index, tokens) => {
-            return token.scopes.includes('keyword.as.sql') && includeTokensWithMatchingScopes(tokens.slice(index + 1, index + 2), ['meta.column.alias.sql', 'meta.column.explicit.alias.sql']).length > 0;
+            return token
+                    .scopes
+                    .includes('keyword.as.sql') && 
+                    includeTokensWithMatchingScopes(
+                      tokens.slice(index + 1, index + 2),
+                      [
+                        'meta.column.alias.sql',
+                        'meta.column.explicit.alias.sql',
+                        'meta.column.explicit.alias.missing.sql'
+                      ])
+                      .length > 0;
           });
 
           if (explicitAlias) {

--- a/server/src/linter/rules/aliasing/AL02.ts
+++ b/server/src/linter/rules/aliasing/AL02.ts
@@ -119,7 +119,6 @@ export class ColumnAlias extends Rule<FileMap>{
             ]
         }
     };
-    const title = 'Remove ambiguous DISTINCT clause';
     const actions: CodeAction[] = [];
     
     this.codeActionKind.map((kind) => {

--- a/server/src/linter/rules/aliasing/AL02.ts
+++ b/server/src/linter/rules/aliasing/AL02.ts
@@ -11,6 +11,7 @@ import { excludeTokensWithMatchingScopes, includeTokensWithMatchingScopes } from
 
 
 export class ColumnAlias extends Rule<FileMap>{
+  readonly is_fix_compatible: boolean = false;
   readonly name: string = "column";
   readonly code: string = "AL02";
   readonly message: string = "Explicit aliasing of columns.";

--- a/server/src/linter/rules/aliasing/AL02.ts
+++ b/server/src/linter/rules/aliasing/AL02.ts
@@ -25,6 +25,7 @@ export class ColumnAlias extends Rule<FileMap>{
   readonly ruleGroup: string = 'aliasing';
 	readonly scope = 'keyword.as.sql';
   readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
+  readonly codeActionTitle = 'Remove explicit alias';
 
   /**
    * Creates an instance of ColumnAlias.
@@ -123,7 +124,7 @@ export class ColumnAlias extends Rule<FileMap>{
     
     this.codeActionKind.map((kind) => {
       const fix = CodeAction.create(
-        title,
+        this.codeActionTitle,
         edit,
         kind
       );

--- a/server/src/linter/rules/aliasing/AL05.ts
+++ b/server/src/linter/rules/aliasing/AL05.ts
@@ -12,6 +12,7 @@ import { ArrayAST, Column, ColumnAST, ColumnFunctionAST, ComparisonAST, Comparis
 
 
 export class UnusedAlias extends Rule<FileMap>{
+  readonly is_fix_compatible: boolean = false;
   readonly name: string = "unused_alias";
   readonly code: string = "AL05";
   readonly message: string = "Columns must use table alias.";

--- a/server/src/linter/rules/aliasing/AL05.ts
+++ b/server/src/linter/rules/aliasing/AL05.ts
@@ -7,7 +7,6 @@ import {
 import { RuleType } from '../enums';
 import { Rule } from '../base';
 import { FileMap } from '../../parser';
-import { excludeTokensWithMatchingScopes, includeTokensWithMatchingScopes } from '../../parser/token';
 import { ArrayAST, Column, ColumnAST, ColumnFunctionAST, ComparisonAST, ComparisonGroupAST, StatementAST } from '../../parser/ast';
 
 
@@ -50,6 +49,13 @@ export class UnusedAlias extends Rule<FileMap>{
     return errors.length > 0 ? errors : null;
   }
 
+  /**
+   * Processes a statement and generates diagnostics for any issues found.
+   * 
+   * @param statement - The statement to process, which can be an instance of `StatementAST`.
+   * @param documentUri - The URI of the document being processed, or null if not applicable.
+   * @returns An array of `Diagnostic` objects representing any issues found in the statement.
+   */
   private processStatement(statement: StatementAST, documentUri: string | null = null): Diagnostic[] {
     const errors: Diagnostic[] = [];
 
@@ -80,9 +86,15 @@ export class UnusedAlias extends Rule<FileMap>{
     }
     
     return errors;
-
   }
 
+  /**
+   * Processes a column and generates diagnostics for any issues found.
+   *
+   * @param column - The column to process, which can be an instance of `ColumnAST` or `ColumnFunctionAST`.
+   * @param documentUri - The URI of the document being processed, or null if not applicable.
+   * @returns An array of `Diagnostic` objects representing any issues found in the column.
+   */
   private processColumn(column: Column, documentUri: string | null = null): Diagnostic[] {
     const errors: Diagnostic[] = [];
 
@@ -102,6 +114,13 @@ export class UnusedAlias extends Rule<FileMap>{
     return errors;
   }
 
+  /**
+   * Processes a comparison or a group of comparisons and returns an array of diagnostics.
+   *
+   * @param comparison - The comparison or group of comparisons to process.
+   * @param documentUri - The URI of the document being processed, if available.
+   * @returns An array of diagnostics generated from processing the comparison(s).
+   */
   private processComparison(comparison: ComparisonGroupAST | ComparisonAST, documentUri: string | null = null): Diagnostic[] {
     const errors: Diagnostic[] = [];
 

--- a/server/src/linter/rules/aliasing/AL06.ts
+++ b/server/src/linter/rules/aliasing/AL06.ts
@@ -1,0 +1,102 @@
+
+import { ServerSettings } from "../../../settings";
+import { Diagnostic } from 'vscode-languageserver/node';
+import { RuleType } from '../enums';
+import { Rule } from '../base';
+import { FileMap } from '../../parser';
+import { StatementAST } from '../../parser/ast';
+import { excludeTokensWithMatchingScopes, includeTokensWithMatchingScopes } from '../../parser/token';
+
+
+export class TableAlias extends Rule<FileMap>{
+  readonly is_fix_compatible: boolean = false;
+  readonly name: string = "table_alias";
+  readonly code: string = "AL06";
+  readonly message: string = "Tables must use an alias.";
+  readonly relatedInformation: string = ".";
+	readonly type: RuleType = RuleType.PARSER;
+  readonly ruleGroup: string = 'aliasing';
+
+  /**
+   * Creates an instance of TableAlias.
+   * @param {ServerSettings} settings The server settings
+   * @param {number} problems The number of problems identified in the source code
+   * @memberof TableAlias
+   */
+  constructor(settings: ServerSettings, problems: number) {
+      super(settings, problems);
+  }
+
+  /**
+   * Evaluates the given Abstract Syntax Tree (AST) to identify redundant aliases in column definitions.
+   * 
+   * @param ast - The Abstract Syntax Tree (AST) representing the SQL file structure.
+   * @param documentUri - The URI of the document being evaluated, or null if not applicable.
+   * @returns An array of Diagnostic objects representing the errors found, or null if no errors are found or the rule is disabled.
+   */
+  evaluate(ast: FileMap, documentUri: string | null = null): Diagnostic[] | null {
+
+    if (this.enabled === false) {
+      return null;
+    }
+		const errors: Diagnostic[] = [];
+    for (const i in ast) {
+      
+      if (ast[i].from) {
+        if (ast[i].from.alias == null) {
+
+          const fromTokens = excludeTokensWithMatchingScopes(
+            ast[i].from.tokens,
+            [
+              'punctuation.whitespace.sql',
+              'punctuation.whitespace.leading.sql',
+              'punctuation.whitespace.trailing.sql',
+              'keyword.join.sql'
+            ]);
+
+          errors.push(this.createDiagnostic({
+            start: {
+              line: fromTokens[0].lineNumber??0,
+              character: fromTokens[0].startIndex
+            },
+            end: {
+              line: fromTokens[fromTokens.length - 1].lineNumber??0,
+              character: fromTokens[fromTokens.length - 1].endIndex
+            }
+          }, documentUri));
+        }
+      }
+
+      if (ast[i].joins) {
+        ast[i].joins.map(join => {
+          if (join.source) {
+            if (join.source.alias == null) {
+
+              const joinTokens = includeTokensWithMatchingScopes(
+                join.source.tokens,
+                [
+                  'entity.name.project.sql',
+                  'entity.name.dataset.sql',
+                  'entity.name.object.sql'
+                ]);
+              errors.push(this.createDiagnostic({
+                start: {
+                  line: joinTokens[0].lineNumber??0,
+                  character: joinTokens[0].startIndex
+                },
+                end: {
+                  line: joinTokens[joinTokens.length - 1].lineNumber??0,
+                  character: joinTokens[joinTokens.length - 1].endIndex
+                }
+              }, documentUri));
+            }
+          }
+        });
+      }
+
+    }
+
+    return errors.length > 0 ? errors : null;
+  }
+
+}

--- a/server/src/linter/rules/aliasing/AL06.ts
+++ b/server/src/linter/rules/aliasing/AL06.ts
@@ -13,7 +13,7 @@ export class TableAlias extends Rule<FileMap>{
   readonly name: string = "table_alias";
   readonly code: string = "AL06";
   readonly message: string = "Tables must use an alias.";
-  readonly relatedInformation: string = ".";
+  readonly relatedInformation: string = "Using aliases for tables simplifies the query, improves readability, and makes it easier to reference table columns.";
 	readonly type: RuleType = RuleType.PARSER;
   readonly ruleGroup: string = 'aliasing';
 
@@ -51,7 +51,7 @@ export class TableAlias extends Rule<FileMap>{
               'punctuation.whitespace.sql',
               'punctuation.whitespace.leading.sql',
               'punctuation.whitespace.trailing.sql',
-              'keyword.join.sql'
+              'keyword.from.sql'
             ]);
 
           errors.push(this.createDiagnostic({

--- a/server/src/linter/rules/aliasing/AL08.ts
+++ b/server/src/linter/rules/aliasing/AL08.ts
@@ -14,6 +14,7 @@ import { sortTokens } from '../../parser/utils';
 
 
 export class UniqueColumn extends Rule<FileMap>{
+  readonly is_fix_compatible: boolean = false;
   readonly name: string = "unique_column";
   readonly code: string = "AL08";
   readonly message: string = "Column names should be unique.";

--- a/server/src/linter/rules/aliasing/AL09.ts
+++ b/server/src/linter/rules/aliasing/AL09.ts
@@ -26,6 +26,8 @@ export class RedundantColumnAlias extends Rule<FileMap>{
 	readonly type: RuleType = RuleType.PARSER;
   readonly diagnosticTags: DiagnosticTag[] = [DiagnosticTag.Unnecessary];
   readonly ruleGroup: string = 'aliasing';
+  readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
+  readonly codeActionTitle = 'Remove redundant column alias';
 
   /**
    * Creates an instance of RedundantColumnAlias.
@@ -108,12 +110,11 @@ export class RedundantColumnAlias extends Rule<FileMap>{
             ]
         }
     };
-    const title = 'Remove redundant column alias';
     const actions: CodeAction[] = [];
     
-    [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix].map((kind) => {
+    this.codeActionKind.map((kind) => {
       const fix = CodeAction.create(
-        title,
+        this.codeActionTitle,
         edit,
         kind
       );

--- a/server/src/linter/rules/aliasing/AL09.ts
+++ b/server/src/linter/rules/aliasing/AL09.ts
@@ -4,7 +4,11 @@ import {
   Diagnostic,
   DiagnosticSeverity,
   Range,
-  DiagnosticTag
+  DiagnosticTag,
+  CodeAction,
+  TextEdit,
+  TextDocumentIdentifier,
+  CodeActionKind
 } from 'vscode-languageserver/node';
 import { RuleType } from '../enums';
 import { Rule } from '../base';
@@ -90,5 +94,30 @@ export class RedundantColumnAlias extends Rule<FileMap>{
     }
 		
     return errors.length > 0 ? errors : null;
+  }
+  
+  /**
+   * Creates a CodeAction to resolve the rule
+   * @param textDocument 
+   * @param diagnostic 
+   * @returns CodeAction
+   */
+  createCodeAction(textDocument: TextDocumentIdentifier, diagnostic: Diagnostic): CodeAction {
+    // Create a TextEdit to remove the trailing whitespace
+    const fix = CodeAction.create(
+        'Remove redundant alias',
+        {
+            changes: {
+                [textDocument.uri]: [
+                    TextEdit.replace(diagnostic.range, '')
+                ]
+            }
+        },
+        CodeActionKind.QuickFix
+    );
+
+    // Associate the fix with the diagnostic
+    fix.diagnostics = [diagnostic];
+    return fix;
   }
 }

--- a/server/src/linter/rules/aliasing/rules.ts
+++ b/server/src/linter/rules/aliasing/rules.ts
@@ -4,11 +4,12 @@ import { ServerSettings } from '../../../settings';
 import { Table } from './AL01';
 import { ColumnAlias } from './AL02';
 import { UnusedAlias } from './AL05';
+import { TableAlias } from './AL06';
 import { UniqueColumn } from './AL08';
 import { RedundantColumnAlias } from './AL09';
 import { FileMap } from '../../parser';
 
-export const classes = [Table, ColumnAlias, UnusedAlias, UniqueColumn, RedundantColumnAlias];
+export const classes = [Table, ColumnAlias, UnusedAlias, TableAlias, UniqueColumn, RedundantColumnAlias];
 
 /**
  * Generates an array of aliasing rules based on the provided settings and problems count.

--- a/server/src/linter/rules/ambiguous/AM01.ts
+++ b/server/src/linter/rules/ambiguous/AM01.ts
@@ -10,6 +10,7 @@ import { FileMap } from '../../parser';
 
 
 export class Distinct extends Rule<FileMap>{
+  readonly is_fix_compatible: boolean = false;
   readonly name: string = "column";
   readonly code: string = "AM01";
   readonly message: string = "Ambiguous use of DISTINCT in a SELECT statement with GROUP BY.";

--- a/server/src/linter/rules/ambiguous/AM01.ts
+++ b/server/src/linter/rules/ambiguous/AM01.ts
@@ -23,6 +23,7 @@ export class Distinct extends Rule<FileMap>{
   readonly diagnosticTags: DiagnosticTag[] = [DiagnosticTag.Unnecessary];
   readonly ruleGroup: string = 'ambiguous';
   readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
+  readonly codeActionTitle = 'Remove ambiguous DISTINCT clause';
 
   /**
    * Creates an instance of Distinct.
@@ -89,12 +90,11 @@ export class Distinct extends Rule<FileMap>{
             ]
         }
     };
-    const title = 'Remove ambiguous DISTINCT clause';
     const actions: CodeAction[] = [];
     
     this.codeActionKind.map((kind) => {
       const fix = CodeAction.create(
-        title,
+        this.codeActionTitle,
         edit,
         kind
       );

--- a/server/src/linter/rules/ambiguous/AM04.ts
+++ b/server/src/linter/rules/ambiguous/AM04.ts
@@ -10,6 +10,7 @@ import { Rule } from '../base';
  * @memberof Linter.Rules
  */
 export class ColumnCount extends Rule<string> {
+  readonly is_fix_compatible: boolean = false;
   readonly name: string = "column_count";
   readonly code: string = "AM04";
   readonly message: string = "Query produces an unknown number of result columns.";

--- a/server/src/linter/rules/base.ts
+++ b/server/src/linter/rules/base.ts
@@ -65,33 +65,59 @@ export abstract class Rule<T extends string | FileMap>{
 		this.pattern.lastIndex = 0;
 
 		const diagnostics: Diagnostic[] = [];
-      
+		
 		let match;
 		while ((match = this.pattern.exec(test)) != null) {
-
-			const start: MatchPosition = this.getLineAndCharacter(test, match.index);
-			const end: MatchPosition = this.getLineAndCharacter(test, this.pattern.lastIndex);
-			const range = {
-				start: { line: start.line, character: start.character },
-				end: { line: end.line, character: end.character }
-			};
-
-			diagnostics.push(this.createDiagnostic(range, documentUri));
+				let groupStartIndex: number;
+				let groupEndIndex: number;
+				if (match.length > 1) {
+					[groupStartIndex, groupEndIndex] = this.getCaptureGroupIndices(match, 1);
+				} else {
+					groupStartIndex = match.index;
+					groupEndIndex = this.pattern.lastIndex;
+				}
+				const start: MatchPosition = this.getLineAndCharacter(test, groupStartIndex);
+				const end: MatchPosition = this.getLineAndCharacter(test, groupEndIndex);
+				const range = {
+						start: { line: start.line, character: start.character },
+						end: { line: end.line, character: end.character }
+				};
+		
+				diagnostics.push(this.createDiagnostic(range, documentUri));
 		}
-
+		
 		return diagnostics;
 		
 	}
+		
+	getCaptureGroupIndices(match: RegExpExecArray, groupNumber: number): [number, number] {
 
-	/**
-	 * Calculates the line and character position of a given index within a string.
-	 *
-	 * @param content - The string content to search within.
-	 * @param matchIndex - The index within the string for which to find the line and character position.
-	 * @returns An object containing the line and character position corresponding to the given index.
-	 * @throws Will throw an error if the match index is out of range of the content.
-	 */
-	getLineAndCharacter(content: string, matchIndex: number):  MatchPosition{
+			if (match[groupNumber] == null) {
+				return [match.index, match.index + match[0].length];
+			}
+
+			const overallMatchStartIndex = match.index;
+			let searchStart = 0;
+			for (let i = 1; i <= groupNumber; i++) {
+					const groupText = match[i];
+					if (groupText == null) {
+							continue; // Skip unmatched groups
+					}
+					const idxInMatch0 = match[0].indexOf(groupText, searchStart);
+					if (idxInMatch0 === -1) {
+							throw new Error('Group text not found in match[0]');
+					}
+					if (i === groupNumber) {
+							const groupStartIndex = overallMatchStartIndex + idxInMatch0;
+							const groupEndIndex = groupStartIndex + groupText.length;
+							return [groupStartIndex, groupEndIndex];
+					}
+					searchStart = idxInMatch0 + groupText.length;
+			}
+			throw new Error('Group number out of range');
+	}
+	
+	getLineAndCharacter(content: string, matchIndex: number): MatchPosition {
 			const lines = content.split('\n');
 			let runningTotal = 0;
 			for (let i = 0; i < lines.length; i++) {

--- a/server/src/linter/rules/base.ts
+++ b/server/src/linter/rules/base.ts
@@ -71,7 +71,7 @@ export abstract class Rule<T extends string | FileMap>{
 				let groupStartIndex: number;
 				let groupEndIndex: number;
 				if (match.length > 1) {
-					[groupStartIndex, groupEndIndex] = this.getCaptureGroupIndices(match, 1);
+					[groupStartIndex, groupEndIndex] = this.getCaptureGroupIndices(match, match.slice(1).findIndex((group) => group != null) + 1);
 				} else {
 					groupStartIndex = match.index;
 					groupEndIndex = this.pattern.lastIndex;

--- a/server/src/linter/rules/base.ts
+++ b/server/src/linter/rules/base.ts
@@ -1,4 +1,4 @@
-import { Diagnostic, DiagnosticSeverity, DiagnosticTag, Range, URI } from 'vscode-languageserver/node';
+import { CodeAction, Diagnostic, DiagnosticSeverity, DiagnosticTag, Range, TextDocumentIdentifier, URI } from 'vscode-languageserver/node';
 import { RuleType } from './enums';
 import { ServerSettings } from '../../settings';
 import { FileMap } from '../parser';
@@ -56,6 +56,8 @@ export abstract class Rule<T extends string | FileMap>{
 	}
 
 	abstract evaluate(test: T, documentUri: string | null): Diagnostic[] | null;
+
+  createCodeAction(textDocument: TextDocumentIdentifier, diagnostic: Diagnostic): CodeAction | null { return null; }
 
 	evaluateMultiRegexTest(test: string, documentUri: string | null = null): Diagnostic[] | null {
 

--- a/server/src/linter/rules/base.ts
+++ b/server/src/linter/rules/base.ts
@@ -57,7 +57,7 @@ export abstract class Rule<T extends string | FileMap>{
 
 	abstract evaluate(test: T, documentUri: string | null): Diagnostic[] | null;
 
-  createCodeAction(textDocument: TextDocumentIdentifier, diagnostic: Diagnostic): CodeAction | null { return null; }
+  createCodeAction(textDocument: TextDocumentIdentifier, diagnostic: Diagnostic): CodeAction[] | null { return null; }
 
 	evaluateMultiRegexTest(test: string, documentUri: string | null = null): Diagnostic[] | null {
 

--- a/server/src/linter/rules/base.ts
+++ b/server/src/linter/rules/base.ts
@@ -101,11 +101,11 @@ export abstract class Rule<T extends string | FileMap>{
 			for (let i = 1; i <= groupNumber; i++) {
 					const groupText = match[i];
 					if (groupText == null) {
-							continue; // Skip unmatched groups
+						continue; // Skip unmatched groups
 					}
 					const idxInMatch0 = match[0].indexOf(groupText, searchStart);
 					if (idxInMatch0 === -1) {
-							throw new Error('Group text not found in match[0]');
+						return [match.index, match.index + match[0].length];
 					}
 					if (i === groupNumber) {
 							const groupStartIndex = overallMatchStartIndex + idxInMatch0;
@@ -114,7 +114,7 @@ export abstract class Rule<T extends string | FileMap>{
 					}
 					searchStart = idxInMatch0 + groupText.length;
 			}
-			throw new Error('Group number out of range');
+			return [match.index, match.index + match[0].length];
 	}
 	
 	getLineAndCharacter(content: string, matchIndex: number): MatchPosition {

--- a/server/src/linter/rules/capitalisation/CP04.ts
+++ b/server/src/linter/rules/capitalisation/CP04.ts
@@ -1,8 +1,13 @@
 import { ServerSettings } from "../../../settings";
 import {
+  CodeAction,
+  CodeActionKind,
   Diagnostic,
+  TextDocumentIdentifier,
+  TextEdit,
 } from 'vscode-languageserver/node';
 import { Rule } from '../base';
+import { globalTokenCache } from '../../parser/tokenCache';
 
 
 /**
@@ -12,13 +17,13 @@ import { Rule } from '../base';
  * @memberof Linter.Rules
  */
 export class Literals extends Rule<string> {
-  readonly is_fix_compatible: boolean = false;
   readonly name: string = "literals";
   readonly code: string = "CP04";
   readonly message: string = "Capitalisation of boolean/null literal";
 	readonly relatedInformation: string = "To maintain consistency and readability, always write the literals `null`, `true`, and `false` in lowercase.";
   readonly pattern: RegExp = /FALSE|TRUE|NULL/gm;
   readonly ruleGroup: string = 'capitalisation';
+  readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
 
   /**
    * Creates an instance of Literals.
@@ -49,5 +54,44 @@ export class Literals extends Rule<string> {
 
     return null;
 
+  }
+  
+  /**
+   * Creates a set of code actions to fix diagnostics.
+   *
+   * @param textDocument - The identifier of the text document where the diagnostic was reported.
+   * @param diagnostic - The diagnostic information about the issue to be fixed.
+   * @returns An array of code actions that can be applied to fix the issue.
+   */
+  createCodeAction(textDocument: TextDocumentIdentifier, diagnostic: Diagnostic): CodeAction[] {
+    const cachedDocument = globalTokenCache.get(textDocument.uri);
+
+    if (!cachedDocument) {
+      return [];
+    }
+
+    const text = cachedDocument.getText(diagnostic.range).toLowerCase();
+
+    const edit = {
+        changes: {
+            [textDocument.uri]: [
+                TextEdit.replace(diagnostic.range, text)
+            ]
+        }
+    };
+    const title = 'Convert to lowercase';
+    const actions: CodeAction[] = [];
+    
+    this.codeActionKind.map((kind) => {
+      const fix = CodeAction.create(
+        title,
+        edit,
+        kind
+      );
+      fix.diagnostics = [diagnostic];
+      actions.push(fix);
+    });
+
+    return actions;
   }
 }

--- a/server/src/linter/rules/capitalisation/CP04.ts
+++ b/server/src/linter/rules/capitalisation/CP04.ts
@@ -12,6 +12,7 @@ import { Rule } from '../base';
  * @memberof Linter.Rules
  */
 export class Literals extends Rule<string> {
+  readonly is_fix_compatible: boolean = false;
   readonly name: string = "literals";
   readonly code: string = "CP04";
   readonly message: string = "Capitalisation of boolean/null literal";

--- a/server/src/linter/rules/capitalisation/CP04.ts
+++ b/server/src/linter/rules/capitalisation/CP04.ts
@@ -24,6 +24,7 @@ export class Literals extends Rule<string> {
   readonly pattern: RegExp = /FALSE|TRUE|NULL/gm;
   readonly ruleGroup: string = 'capitalisation';
   readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
+  readonly codeActionTitle = 'Convert to lowercase';
 
   /**
    * Creates an instance of Literals.
@@ -79,12 +80,11 @@ export class Literals extends Rule<string> {
             ]
         }
     };
-    const title = 'Convert to lowercase';
     const actions: CodeAction[] = [];
     
     this.codeActionKind.map((kind) => {
       const fix = CodeAction.create(
-        title,
+        this.codeActionTitle,
         edit,
         kind
       );

--- a/server/src/linter/rules/convention/CV02.ts
+++ b/server/src/linter/rules/convention/CV02.ts
@@ -10,6 +10,7 @@ import { Rule } from '../base';
  * @memberof Linter.Rules
  */
 export class Coalesce extends Rule<string> {
+  readonly is_fix_compatible: boolean = false;
   readonly name: string = "coalesce";
   readonly code: string = "CV02";
   readonly message: string = "Use COALESCE instead of IFNULL or NVL.";

--- a/server/src/linter/rules/convention/CV02.ts
+++ b/server/src/linter/rules/convention/CV02.ts
@@ -1,5 +1,5 @@
 import { ServerSettings } from "../../../settings";
-import { Diagnostic, DiagnosticSeverity } from 'vscode-languageserver/node';
+import { CodeAction, CodeActionKind, CodeActionParams, Diagnostic, DiagnosticSeverity, TextDocumentIdentifier, TextEdit } from 'vscode-languageserver/node';
 import { Rule } from '../base';
 
 
@@ -10,14 +10,14 @@ import { Rule } from '../base';
  * @memberof Linter.Rules
  */
 export class Coalesce extends Rule<string> {
-  readonly is_fix_compatible: boolean = false;
   readonly name: string = "coalesce";
   readonly code: string = "CV02";
   readonly message: string = "Use COALESCE instead of IFNULL or NVL.";
 	readonly relatedInformation: string = "Using `COALESCE` instead of `IFNULL` or `NVL` ensures that SQL queries are portable, consistent, and easier to maintain across different databases.";
-  readonly pattern: RegExp = /(?:ifnull|nvl)\s*\(/gmi;
+  readonly pattern: RegExp = /(ifnull|nvl)\s*\(/gmi;
   readonly severity: DiagnosticSeverity = DiagnosticSeverity.Warning;
   readonly ruleGroup: string = 'convention';
+  readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
 
   /**
    * Creates an instance of Coalesce.
@@ -48,5 +48,36 @@ export class Coalesce extends Rule<string> {
 
     return null;
 
+  }
+  
+  /**
+   * Creates a set of code actions to fix diagnostics.
+   *
+   * @param textDocument - The identifier of the text document where the diagnostic was reported.
+   * @param diagnostic - The diagnostic information about the issue to be fixed.
+   * @returns An array of code actions that can be applied to fix the issue.
+   */
+  createCodeAction(textDocument: TextDocumentIdentifier, diagnostic: Diagnostic): CodeAction[] {
+    const edit = {
+        changes: {
+            [textDocument.uri]: [
+                TextEdit.replace(diagnostic.range, 'coalesce')
+            ]
+        }
+    };
+    const title = 'Replace with `coalesce`';
+    const actions: CodeAction[] = [];
+    
+    this.codeActionKind.map((kind) => {
+      const fix = CodeAction.create(
+        title,
+        edit,
+        kind
+      );
+      fix.diagnostics = [diagnostic];
+      actions.push(fix);
+    });
+
+    return actions;
   }
 }

--- a/server/src/linter/rules/convention/CV02.ts
+++ b/server/src/linter/rules/convention/CV02.ts
@@ -18,6 +18,7 @@ export class Coalesce extends Rule<string> {
   readonly severity: DiagnosticSeverity = DiagnosticSeverity.Warning;
   readonly ruleGroup: string = 'convention';
   readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
+  readonly codeActionTitle = 'Replace with `coalesce`';
 
   /**
    * Creates an instance of Coalesce.
@@ -65,12 +66,11 @@ export class Coalesce extends Rule<string> {
             ]
         }
     };
-    const title = 'Replace with `coalesce`';
     const actions: CodeAction[] = [];
     
     this.codeActionKind.map((kind) => {
       const fix = CodeAction.create(
-        title,
+        this.codeActionTitle,
         edit,
         kind
       );

--- a/server/src/linter/rules/convention/CV08.ts
+++ b/server/src/linter/rules/convention/CV08.ts
@@ -18,6 +18,7 @@ export class LeftJoin extends Rule<string> {
   readonly severity: DiagnosticSeverity = DiagnosticSeverity.Warning;
   readonly ruleGroup: string = 'convention';
   readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
+  readonly codeActionTitle = 'Replace with `left join`';
 
   /**
    * Creates an instance of LeftJoin.
@@ -65,12 +66,11 @@ export class LeftJoin extends Rule<string> {
             ]
         }
     };
-    const title = 'Replace with `left join`';
     const actions: CodeAction[] = [];
     
     this.codeActionKind.map((kind) => {
       const fix = CodeAction.create(
-        title,
+        this.codeActionTitle,
         edit,
         kind
       );

--- a/server/src/linter/rules/convention/CV08.ts
+++ b/server/src/linter/rules/convention/CV08.ts
@@ -10,6 +10,7 @@ import { Rule } from '../base';
  * @memberof Linter.Rules
  */
 export class LeftJoin extends Rule<string> {
+  readonly is_fix_compatible: boolean = false;
   readonly name: string = "else_null";
   readonly code: string = "CV08";
   readonly message: string = "Use LEFT JOIN instead of RIGHT JOIN.";

--- a/server/src/linter/rules/layout/LT01.ts
+++ b/server/src/linter/rules/layout/LT01.ts
@@ -33,6 +33,7 @@ export class TrailingSpaces extends Rule<string> {
   readonly severity: DiagnosticSeverity = DiagnosticSeverity.Warning;
   readonly ruleGroup: string = 'layout';
   readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
+  readonly codeActionTitle = 'Remove trailing whitespace';
 
   /**
    * Creates an instance of TrailingSpaces.
@@ -85,7 +86,7 @@ export class TrailingSpaces extends Rule<string> {
     
     this.codeActionKind.map((kind) => {
       const fix = CodeAction.create(
-        title,
+        this.codeActionTitle,
         edit,
         kind
       );

--- a/server/src/linter/rules/layout/LT01.ts
+++ b/server/src/linter/rules/layout/LT01.ts
@@ -81,7 +81,6 @@ export class TrailingSpaces extends Rule<string> {
             ]
         }
     };
-    const title = 'Remove trailing whitespace';
     const actions: CodeAction[] = [];
     
     this.codeActionKind.map((kind) => {

--- a/server/src/linter/rules/layout/LT04.ts
+++ b/server/src/linter/rules/layout/LT04.ts
@@ -11,6 +11,7 @@ import { ServerSettings } from "../../../settings";
 import { RuleType } from '../enums';
 import {
   Diagnostic,
+  TextDocumentIdentifier,
 } from 'vscode-languageserver/node';
 import { Rule } from '../base';
 import { FileMap } from '../../parser';
@@ -23,6 +24,7 @@ import { FileMap } from '../../parser';
  * @memberof Linter.Rules
  */
 export class TrailingComma extends Rule<FileMap> {
+  readonly is_fix_compatible: boolean = false;
   readonly name: string = "trailing_commas";
   readonly code: string = "LT04";
   readonly type: RuleType = RuleType.PARSER;
@@ -92,4 +94,5 @@ export class TrailingComma extends Rule<FileMap> {
 
     return errors.length > 0 ? errors : null;
   }
+  createCodeAction(textDocument: TextDocumentIdentifier, diagnostic: Diagnostic): null { return null; }
 }

--- a/server/src/linter/rules/layout/LT06.ts
+++ b/server/src/linter/rules/layout/LT06.ts
@@ -17,6 +17,7 @@ import { ColumnFunctionAST, ComparisonAST, ComparisonGroupAST } from '../../pars
  * @memberof Linter.Rules
  */
 export class Functions extends Rule<FileMap> {
+  readonly is_fix_compatible: boolean = false;
   readonly name: string = "functions";
   readonly code: string = "LT06";
   readonly type: RuleType = RuleType.PARSER;

--- a/server/src/linter/rules/layout/LT06.ts
+++ b/server/src/linter/rules/layout/LT06.ts
@@ -161,7 +161,7 @@ export class Functions extends Rule<FileMap> {
             ]
         }
     };
-    const title = 'Remove trailing whitespace';
+    const title = 'Remove redundant whitespace';
     const actions: CodeAction[] = [];
     
     this.codeActionKind.map((kind) => {

--- a/server/src/linter/rules/layout/LT06.ts
+++ b/server/src/linter/rules/layout/LT06.ts
@@ -29,6 +29,7 @@ export class Functions extends Rule<FileMap> {
   readonly severity: DiagnosticSeverity = DiagnosticSeverity.Warning;
   readonly ruleGroup: string = 'layout';
   readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
+  readonly codeActionTitle = 'Remove redundant whitespace';
 
   /**
    * Creates an instance of Functions.
@@ -161,12 +162,11 @@ export class Functions extends Rule<FileMap> {
             ]
         }
     };
-    const title = 'Remove redundant whitespace';
     const actions: CodeAction[] = [];
     
     this.codeActionKind.map((kind) => {
       const fix = CodeAction.create(
-        title,
+        this.codeActionTitle,
         edit,
         kind
       );

--- a/server/src/linter/rules/layout/LT09.ts
+++ b/server/src/linter/rules/layout/LT09.ts
@@ -16,6 +16,7 @@ import { ColumnAST } from '../../parser/ast';
  * @memberof Linter.Rules
  */
 export class SelectTargets extends Rule<FileMap> {
+  readonly is_fix_compatible: boolean = false;
   readonly name: string = "select_targets";
   readonly code: string = "LT09";
   readonly type: RuleType = RuleType.PARSER;

--- a/server/src/linter/rules/layout/LT10.ts
+++ b/server/src/linter/rules/layout/LT10.ts
@@ -20,6 +20,7 @@ import { Rule } from '../base';
  * @memberof Linter.Rules
  */
 export class SelectModifiers extends Rule<string> {
+  readonly is_fix_compatible: boolean = false;
   readonly name: string = "select_modifiers_check";
   readonly code: string = "LT10";
   readonly message: string = "SELECT modifiers (e.g. DISTINCT) must be on the same line as SELECT";

--- a/server/src/linter/rules/layout/LT11.ts
+++ b/server/src/linter/rules/layout/LT11.ts
@@ -24,7 +24,7 @@ export class UnionCheck extends Rule<string> {
   readonly name: string = "union_checks";
   readonly code: string = "LT11";
   readonly message: string = "Union operators should be surrounded by newlines.";
-  readonly pattern: RegExp = /(?<!\n)\bunion( (all|distinct)|(?!( (all|distinct))))|\bunion( (all|distinct)|(?!( (all|distinct))))(?!\n)/gi;
+  readonly pattern: RegExp = /\S( *union +(?:all|distinct)) *|\n( *union (?:all|distinct) +)\S/gmi;
   readonly relatedInformation: string = "The `UNION` operator should be placed on a separate line, surrounded by newlines before and after.";
   readonly ruleGroup: string = 'layout';
 

--- a/server/src/linter/rules/layout/LT11.ts
+++ b/server/src/linter/rules/layout/LT11.ts
@@ -20,6 +20,7 @@ import { Rule } from '../base';
  * @memberof Linter.Rules
  */
 export class UnionCheck extends Rule<string> {
+  readonly is_fix_compatible: boolean = false;
   readonly name: string = "union_checks";
   readonly code: string = "LT11";
   readonly message: string = "Union operators should be surrounded by newlines.";

--- a/server/src/linter/rules/layout/LT12.ts
+++ b/server/src/linter/rules/layout/LT12.ts
@@ -11,6 +11,7 @@ import { Diagnostic } from 'vscode-languageserver';
 import { Rule } from '../base';
 
 export class EndofFile extends Rule<string> {
+  readonly is_fix_compatible: boolean = false;
 	readonly name: string = "end_of_file";
 	readonly code: string = "LT12";
 	readonly message: string = "Files must end with a single trailing newline.";

--- a/server/src/linter/rules/layout/LT12.ts
+++ b/server/src/linter/rules/layout/LT12.ts
@@ -18,6 +18,7 @@ export class EndofFile extends Rule<string> {
 	readonly pattern: RegExp = /(?:\S(\n{2,}|\n* +\n?)$|\S($))/g;
   readonly ruleGroup: string = 'layout';
   readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
+  readonly codeActionTitle = 'Fix trailing newline';
 
 
 	constructor(settings: any, problems: number) {
@@ -59,12 +60,11 @@ export class EndofFile extends Rule<string> {
             ]
         }
     };
-    const title = 'Fix trailing newline';
     const actions: CodeAction[] = [];
     
     this.codeActionKind.map((kind) => {
       const fix = CodeAction.create(
-        title,
+        this.codeActionTitle,
         edit,
         kind
       );

--- a/server/src/linter/rules/layout/LT12.ts
+++ b/server/src/linter/rules/layout/LT12.ts
@@ -59,7 +59,7 @@ export class EndofFile extends Rule<string> {
             ]
         }
     };
-    const title = 'Remove trailing whitespace';
+    const title = 'Fix trailing newline';
     const actions: CodeAction[] = [];
     
     this.codeActionKind.map((kind) => {

--- a/server/src/linter/rules/layout/LT12.ts
+++ b/server/src/linter/rules/layout/LT12.ts
@@ -15,7 +15,7 @@ export class EndofFile extends Rule<string> {
 	readonly code: string = "LT12";
 	readonly message: string = "Files must end with a single trailing newline.";
 	readonly relatedInformation: string = "Ensuring a single trailing newline at the end of files promotes clean and predictable code formatting.";
-	readonly pattern: RegExp = /\S(\n{2,}|\n* +)\n?$/g;
+	readonly pattern: RegExp = /(?:\S(\n{2,}|\n* +\n?)$|\S($))/g;
   readonly ruleGroup: string = 'layout';
   readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
 

--- a/server/src/linter/rules/layout/LT13.ts
+++ b/server/src/linter/rules/layout/LT13.ts
@@ -82,7 +82,7 @@ export class StartOfFile extends Rule<string> {
             ]
         }
     };
-    const title = 'Remove trailing whitespace';
+    const title = 'Fix start of file';
     const actions: CodeAction[] = [];
     
     this.codeActionKind.map((kind) => {

--- a/server/src/linter/rules/layout/LT13.ts
+++ b/server/src/linter/rules/layout/LT13.ts
@@ -20,6 +20,7 @@ import { Rule } from '../base';
  * @memberof Linter.Rules
  */
 export class StartOfFile extends Rule<string> {
+  readonly is_fix_compatible: boolean = false;
   readonly name: string = "start_of_file";
   readonly code: string = "LT13";
   readonly message: string = "Files must not begin with newlines or whitespace.";

--- a/server/src/linter/rules/layout/LT13.ts
+++ b/server/src/linter/rules/layout/LT13.ts
@@ -31,6 +31,7 @@ export class StartOfFile extends Rule<string> {
   readonly pattern: RegExp = /^[\s]/;
   readonly ruleGroup: string = 'layout';
   readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
+  readonly codeActionTitle = 'Fix start of file';
 
 
   /**
@@ -82,12 +83,11 @@ export class StartOfFile extends Rule<string> {
             ]
         }
     };
-    const title = 'Fix start of file';
     const actions: CodeAction[] = [];
     
     this.codeActionKind.map((kind) => {
       const fix = CodeAction.create(
-        title,
+        this.codeActionTitle,
         edit,
         kind
       );

--- a/server/src/linter/rules/layout/LT15.ts
+++ b/server/src/linter/rules/layout/LT15.ts
@@ -37,6 +37,7 @@ export class ComparisonOperators extends Rule<FileMap> {
   readonly relatedInformation: string = "When the equal (`=`) signs in a `WHERE` clause or join conditions are misaligned across multiple rows, it reduces the readability and consistency of the query.";
   readonly ruleGroup: string = 'layout';
   readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
+  readonly codeActionTitle = 'Format comparison operators';
 
   /**
    * Creates an instance of ComparisonOperators.
@@ -185,12 +186,11 @@ export class ComparisonOperators extends Rule<FileMap> {
             ]
         }
     };
-    const title = 'Format comparison operators';
     const actions: CodeAction[] = [];
     
     this.codeActionKind.map((kind) => {
       const fix = CodeAction.create(
-        title,
+        this.codeActionTitle,
         edit,
         kind
       );

--- a/server/src/linter/rules/layout/LT15.ts
+++ b/server/src/linter/rules/layout/LT15.ts
@@ -24,6 +24,7 @@ import { ComparisonAST, ComparisonGroupAST } from '../../parser/ast';
  * @memberof Linter.Rules
  */
 export class ComparisonOperators extends Rule<FileMap> {
+  readonly is_fix_compatible: boolean = false;
   readonly name: string = "comparison_operators";
   readonly code: string = "LT15";
   readonly type: RuleType = RuleType.PARSER;

--- a/server/src/linter/rules/layout/LT15.ts
+++ b/server/src/linter/rules/layout/LT15.ts
@@ -10,12 +10,18 @@
 import { ServerSettings } from "../../../settings";
 import { RuleType } from '../enums';
 import {
-  Diagnostic, Range
+  CodeAction,
+  CodeActionKind,
+  Diagnostic, DocumentUri, Range,
+  TextDocumentIdentifier,
+  TextEdit
 } from 'vscode-languageserver/node';
 import { Rule } from '../base';
 import { FileMap } from '../../parser';
 import { ComparisonAST, ComparisonGroupAST } from '../../parser/ast';
 
+type RangeCache = Map<string, number>
+const documentCache: Map<DocumentUri, RangeCache> = new Map<DocumentUri, RangeCache>();
 
 /**
  * The ComparisonOperators rule
@@ -24,13 +30,13 @@ import { ComparisonAST, ComparisonGroupAST } from '../../parser/ast';
  * @memberof Linter.Rules
  */
 export class ComparisonOperators extends Rule<FileMap> {
-  readonly is_fix_compatible: boolean = false;
   readonly name: string = "comparison_operators";
   readonly code: string = "LT15";
   readonly type: RuleType = RuleType.PARSER;
   readonly message: string = "Align equal sign in comparison blocks.";
   readonly relatedInformation: string = "When the equal (`=`) signs in a `WHERE` clause or join conditions are misaligned across multiple rows, it reduces the readability and consistency of the query.";
   readonly ruleGroup: string = 'layout';
+  readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
 
   /**
    * Creates an instance of ComparisonOperators.
@@ -62,7 +68,7 @@ export class ComparisonOperators extends Rule<FileMap> {
       const where = ast[i].where;
 
       if (where instanceof ComparisonGroupAST && where.comparisons.length > 1) {
-        errors.push(...this.processComparisonGroup(where));
+        errors.push(...this.processComparisonGroup(where, documentUri));
       }
 
       const joins = ast[i].joins;
@@ -72,7 +78,7 @@ export class ComparisonOperators extends Rule<FileMap> {
 
       joins.map((join) => {
         if (join.on instanceof ComparisonGroupAST) {
-          errors.push(...this.processComparisonGroup(join.on));
+          errors.push(...this.processComparisonGroup(join.on, documentUri));
         }
       });
 
@@ -83,14 +89,18 @@ export class ComparisonOperators extends Rule<FileMap> {
 
   private processComparisonGroup(comparison: ComparisonGroupAST, documentUri: string | null = null): Diagnostic[] {
     const errors: Diagnostic[] = [];
-
     const operators: Range[] = [];
     let operatorIndex: number | null = null;
     let indexError = false;
+    const operatorIndexes: number[] = [];
+    let cache = documentCache.get(documentUri!);
+    if (!cache) {
+      cache = new Map<string, number>();
+    }
     
     for (const comp of comparison.comparisons) {
       if (comp instanceof ComparisonGroupAST && comp.comparisons.length > 1) {
-        errors.push(...this.processComparisonGroup(comp));
+        errors.push(...this.processComparisonGroup(comp, documentUri));
       } else if (comp instanceof ComparisonAST) {
 
         if (comp.operator == null) {
@@ -101,15 +111,17 @@ export class ComparisonOperators extends Rule<FileMap> {
         const offset = operator.indexOf('=');
         if (offset > -1) {
           const operatorToken = comp.tokens.filter((token) => token.value === operator)[0];
+          const index = operatorToken.startIndex + offset;
+          operatorIndexes.push(index);
           if (operatorIndex == null) {
-            operatorIndex = operatorToken.startIndex + offset;
-          } else if (operatorIndex !== operatorToken.startIndex + offset) {
+            operatorIndex = index;
+          } else if (operatorIndex !== index) {
             indexError = true;
           }
           operators.push({
             start: {
               line: operatorToken.lineNumber!,
-              character: operatorToken.startIndex + offset
+              character: index
             },
             end: {
               line: operatorToken.lineNumber!,
@@ -121,10 +133,71 @@ export class ComparisonOperators extends Rule<FileMap> {
     }
 
     if (indexError) {
-      operators.map((operator) => errors.push(this.createDiagnostic(operator, documentUri)));
+      const requiredIndex = Math.max(...operatorIndexes);
+      operators.map((operator) => {
+        cache!.set(this.createCacheKey(operator), requiredIndex);
+        errors.push(this.createDiagnostic(operator, documentUri));
+      });
     }
+
+    documentCache.set(documentUri!, cache);
 
     return errors;
 
+  }
+
+  /**
+   * Generates a unique cache key based on the provided range.
+   *
+   * @param range - The range object containing start and end positions.
+   * @returns A string that uniquely identifies the range.
+   */
+  private createCacheKey(range: Range): string {
+    return `${range.start.line}|${range.start.character}|${range.end.line}|${range.end.character}`;
+  }
+  
+  /**
+   * Creates a set of code actions to fix diagnostics.
+   *
+   * @param textDocument - The identifier of the text document where the diagnostic was reported.
+   * @param diagnostic - The diagnostic information about the issue to be fixed.
+   * @returns An array of code actions that can be applied to fix the issue.
+   */
+  createCodeAction(textDocument: TextDocumentIdentifier, diagnostic: Diagnostic): CodeAction[] {
+    const cachedDocument = documentCache.get(textDocument.uri);
+    let text = '=';
+    if (!cachedDocument) {
+      return [];
+    }
+
+    const requiredIndex = cachedDocument.get(this.createCacheKey(diagnostic.range));
+    if (requiredIndex == null) {
+      return [];
+    }
+    
+    const offset = requiredIndex - diagnostic.range.start.character;
+    text = ' '.repeat(offset) + text;
+  
+    const edit = {
+        changes: {
+            [textDocument.uri]: [
+                TextEdit.replace(diagnostic.range, text)
+            ]
+        }
+    };
+    const title = 'Remove trailing whitespace';
+    const actions: CodeAction[] = [];
+    
+    this.codeActionKind.map((kind) => {
+      const fix = CodeAction.create(
+        title,
+        edit,
+        kind
+      );
+      fix.diagnostics = [diagnostic];
+      actions.push(fix);
+    });
+
+    return actions;
   }
 }

--- a/server/src/linter/rules/layout/LT15.ts
+++ b/server/src/linter/rules/layout/LT15.ts
@@ -174,7 +174,7 @@ export class ComparisonOperators extends Rule<FileMap> {
     if (requiredIndex == null) {
       return [];
     }
-    
+
     const offset = requiredIndex - diagnostic.range.start.character;
     text = ' '.repeat(offset) + text;
   
@@ -185,7 +185,7 @@ export class ComparisonOperators extends Rule<FileMap> {
             ]
         }
     };
-    const title = 'Remove trailing whitespace';
+    const title = 'Format comparison operators';
     const actions: CodeAction[] = [];
     
     this.codeActionKind.map((kind) => {

--- a/server/src/linter/rules/structure/ST01.ts
+++ b/server/src/linter/rules/structure/ST01.ts
@@ -25,6 +25,7 @@ export class ElseNull extends Rule<string> {
   readonly diagnosticTags: DiagnosticTag[] = [DiagnosticTag.Unnecessary];
   readonly ruleGroup: string = 'layout';
   readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
+  readonly codeActionTitle = 'Remove redundant `else null`';
 
   /**
    * Creates an instance of ElseNull.
@@ -72,12 +73,11 @@ export class ElseNull extends Rule<string> {
             ]
         }
     };
-    const title = 'Remove redundant `else null`';
     const actions: CodeAction[] = [];
     
     this.codeActionKind.map((kind) => {
       const fix = CodeAction.create(
-        title,
+        this.codeActionTitle,
         edit,
         kind
       );

--- a/server/src/linter/rules/structure/ST01.ts
+++ b/server/src/linter/rules/structure/ST01.ts
@@ -21,7 +21,7 @@ export class ElseNull extends Rule<string> {
   readonly code: string = "ST01";
   readonly message: string = "Omit `else null`.";
 	readonly relatedInformation: string = "Do not specify redundant `else null` in a case when statement. Including `ELSE NULL` at the end of a `CASE WHEN` statement adds unnecessary complexity to the query.";
-  readonly pattern: RegExp = /(?<!\S)\s+else\s+null +/gmi;
+  readonly pattern: RegExp = /(?<=\S)\s+else\s+null */gmi;
   readonly diagnosticTags: DiagnosticTag[] = [DiagnosticTag.Unnecessary];
   readonly ruleGroup: string = 'layout';
   readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];

--- a/server/src/linter/rules/structure/ST01.ts
+++ b/server/src/linter/rules/structure/ST01.ts
@@ -1,7 +1,11 @@
 import { ServerSettings } from "../../../settings";
 import {
+  CodeAction,
+  CodeActionKind,
   Diagnostic,
   DiagnosticTag,
+  TextDocumentIdentifier,
+  TextEdit,
 } from 'vscode-languageserver/node';
 import { Rule } from '../base';
 
@@ -13,14 +17,14 @@ import { Rule } from '../base';
  * @memberof Linter.Rules
  */
 export class ElseNull extends Rule<string> {
-  readonly is_fix_compatible: boolean = false;
   readonly name: string = "else_null";
   readonly code: string = "ST01";
   readonly message: string = "Omit `else null`.";
 	readonly relatedInformation: string = "Do not specify redundant `else null` in a case when statement. Including `ELSE NULL` at the end of a `CASE WHEN` statement adds unnecessary complexity to the query.";
-  readonly pattern: RegExp = /else\s+null/gmi;
+  readonly pattern: RegExp = /(?<!\S)\s+else\s+null +/gmi;
   readonly diagnosticTags: DiagnosticTag[] = [DiagnosticTag.Unnecessary];
   readonly ruleGroup: string = 'layout';
+  readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
 
   /**
    * Creates an instance of ElseNull.
@@ -51,5 +55,36 @@ export class ElseNull extends Rule<string> {
 
     return null;
 
+  }
+  
+  /**
+   * Creates a set of code actions to fix diagnostics.
+   *
+   * @param textDocument - The identifier of the text document where the diagnostic was reported.
+   * @param diagnostic - The diagnostic information about the issue to be fixed.
+   * @returns An array of code actions that can be applied to fix the issue.
+   */
+  createCodeAction(textDocument: TextDocumentIdentifier, diagnostic: Diagnostic): CodeAction[] {
+    const edit = {
+        changes: {
+            [textDocument.uri]: [
+                TextEdit.replace(diagnostic.range, '')
+            ]
+        }
+    };
+    const title = 'Remove redundant `else null`';
+    const actions: CodeAction[] = [];
+    
+    this.codeActionKind.map((kind) => {
+      const fix = CodeAction.create(
+        title,
+        edit,
+        kind
+      );
+      fix.diagnostics = [diagnostic];
+      actions.push(fix);
+    });
+
+    return actions;
   }
 }

--- a/server/src/linter/rules/structure/ST01.ts
+++ b/server/src/linter/rules/structure/ST01.ts
@@ -13,6 +13,7 @@ import { Rule } from '../base';
  * @memberof Linter.Rules
  */
 export class ElseNull extends Rule<string> {
+  readonly is_fix_compatible: boolean = false;
   readonly name: string = "else_null";
   readonly code: string = "ST01";
   readonly message: string = "Omit `else null`.";

--- a/server/src/linter/rules/structure/ST07.ts
+++ b/server/src/linter/rules/structure/ST07.ts
@@ -13,6 +13,7 @@ import { Rule } from '../base';
  * @memberof Linter.Rules
  */
 export class Using extends Rule<string> {
+  readonly is_fix_compatible: boolean = false;
   readonly name: string = "using";
   readonly code: string = "ST07";
   readonly message: string = "Specify join keys instead of using USING.";

--- a/server/src/linter/rules/structure/ST08.ts
+++ b/server/src/linter/rules/structure/ST08.ts
@@ -12,6 +12,7 @@ import { Rule } from '../base';
  * @memberof Linter.Rules
  */
 export class Distinct extends Rule<string> {
+  readonly is_fix_compatible: boolean = false;
   readonly name: string = "distinct";
   readonly code: string = "ST08";
   readonly message: string = "DISTINCT used with parentheses.";

--- a/server/src/linter/syntaxes/googlesql.tmLanguage.json
+++ b/server/src/linter/syntaxes/googlesql.tmLanguage.json
@@ -762,7 +762,7 @@
             "4": { "name": "keyword.as.sql" },
             "5": { "name": "entity.name.tag" }
           },
-          "match": "(?i)([\\w_]+)(\\.)([\\w_]+)[ \\t]+(as)[ \\t]+(\\3)(?=\\s*?(?:,|\\n|from))",
+          "match": "(?i)(?:([\\w_]+)(\\.))?([\\w_]+)[ \\t]+(as)[ \\t]+(\\3)(?=\\s*?(?:,|\\n|from))",
           "name": "meta.column.explicit.alias.redundant.sql"
         },
         {
@@ -772,7 +772,7 @@
             "3": { "name": "entity.other.column.sql" },
             "4": { "name": "entity.name.tag" }
           },
-          "match": "(?i)([\\w_]+)(\\.)([\\w_]+)[ \\t]+(?:(?>as|(\\3)))(?=\\s*?(?:,|\\n|from))",
+          "match": "(?i)(?:([\\w_]+)(\\.))?([\\w_]+)[ \\t]+(?:(?>as|(\\3)))(?=\\s*?(?:,|\\n|from))",
           "name": "meta.column.implicit.alias.redundant.sql"
         },
         {
@@ -783,7 +783,7 @@
             "4": { "name": "keyword.as.sql" },
             "5": { "name": "entity.name.tag" }
           },
-          "match": "(?i)([\\w_]+)(\\.)([\\w_]+)[ \\t]+(as)[ \\t]+([\\w_]+)(?=\\s*?(?:,|\\n|from))",
+          "match": "(?i)(?:([\\w_]+)(\\.))?([\\w_]+)[ \\t]+(as)[ \\t]+([\\w_]+)(?=\\s*?(?:,|\\n|from))",
           "name": "meta.column.explicit.alias.sql"
         },
         {
@@ -793,7 +793,7 @@
             "3": { "name": "entity.other.column.sql" },
             "4": { "name": "keyword.as.sql" }
           },
-          "match": "(?i)([\\w_]+)(\\.)([\\w_]+)[ \\t]+(as)(?=\\s*?(?:,|\\n|from))",
+          "match": "(?i)(?:([\\w_]+)(\\.))?([\\w_]+)[ \\t]+(as)(?=\\s*?(?:,|\\n|from))",
           "name": "meta.column.explicit.alias.missing.sql"
         },
         {

--- a/server/src/linter/syntaxes/googlesql.tmLanguage.json
+++ b/server/src/linter/syntaxes/googlesql.tmLanguage.json
@@ -762,8 +762,39 @@
             "4": { "name": "keyword.as.sql" },
             "5": { "name": "entity.name.tag" }
           },
+          "match": "(?i)([\\w_]+)(\\.)([\\w_]+)[ \\t]+(as)[ \\t]+(\\3)(?=\\s*?(?:,|\\n|from))",
+          "name": "meta.column.explicit.alias.redundant.sql"
+        },
+        {
+          "captures": {
+            "1": { "name": "entity.name.alias.sql" },
+            "2": { "name": "punctuation.separator.period.sql" },
+            "3": { "name": "entity.other.column.sql" },
+            "4": { "name": "entity.name.tag" }
+          },
+          "match": "(?i)([\\w_]+)(\\.)([\\w_]+)[ \\t]+(?:(?>as|(\\3)))(?=\\s*?(?:,|\\n|from))",
+          "name": "meta.column.implicit.alias.redundant.sql"
+        },
+        {
+          "captures": {
+            "1": { "name": "entity.name.alias.sql" },
+            "2": { "name": "punctuation.separator.period.sql" },
+            "3": { "name": "entity.other.column.sql" },
+            "4": { "name": "keyword.as.sql" },
+            "5": { "name": "entity.name.tag" }
+          },
           "match": "(?i)([\\w_]+)(\\.)([\\w_]+)[ \\t]+(as)[ \\t]+([\\w_]+)(?=\\s*?(?:,|\\n|from))",
           "name": "meta.column.explicit.alias.sql"
+        },
+        {
+          "captures": {
+            "1": { "name": "entity.name.alias.sql" },
+            "2": { "name": "punctuation.separator.period.sql" },
+            "3": { "name": "entity.other.column.sql" },
+            "4": { "name": "keyword.as.sql" }
+          },
+          "match": "(?i)([\\w_]+)(\\.)([\\w_]+)[ \\t]+(as)(?=\\s*?(?:,|\\n|from))",
+          "name": "meta.column.explicit.alias.missing.sql"
         },
         {
           "captures": {
@@ -833,6 +864,13 @@
           },
           "match": "(?i)(?:(as)[ \\t]+)?([\\w_]+)(?=\\s*?(?:,|\\n|from))",
           "name": "meta.column.alias.sql"
+        },
+        {
+          "captures": {
+            "1": { "name": "keyword.as.sql" }
+          },
+          "match": "(?i)(?:(as)(?=\\s*?(?:,|\\n|from)))",
+          "name": "meta.column.alias.missing.sql"
         },
         {
           "captures": {

--- a/server/src/linter/syntaxes/syntax.json
+++ b/server/src/linter/syntaxes/syntax.json
@@ -790,14 +790,8 @@
         "entity.name.alias.sql"
       ],
       "type": "from",
-      "lookahead": 0,
-      "negativeLookahead": [
-        "keyword.join.sql",
-        "keyword.where.sql",
-        "keyword.group.sql",
-        "keyword.order.sql",
-        "keyword.select.limit.sql"
-      ],
+      "lookahead": 5,
+      "negativeLookahead": null,
       "recursive": false,
       "children": null,
       "end": null
@@ -812,14 +806,8 @@
         "entity.name.alias.sql"
       ],
       "type": "from",
-      "lookahead": 0,
-      "negativeLookahead": [
-        "keyword.join.sql",
-        "keyword.where.sql",
-        "keyword.group.sql",
-        "keyword.order.sql",
-        "keyword.select.limit.sql"
-      ],
+      "lookahead": 4,
+      "negativeLookahead": null,
       "recursive": false,
       "children": null,
       "end": null
@@ -864,14 +852,8 @@
         "entity.name.alias.sql"
       ],
       "type": "from",
-      "lookahead": 0,
-      "negativeLookahead": [
-        "keyword.join.sql",
-        "keyword.where.sql",
-        "keyword.group.sql",
-        "keyword.order.sql",
-        "keyword.select.limit.sql"
-      ],
+      "lookahead": 4,
+      "negativeLookahead": null,
       "recursive": false,
       "children": null,
       "end": null
@@ -885,14 +867,8 @@
         "entity.name.alias.sql"
       ],
       "type": "from",
-      "lookahead": 0,
-      "negativeLookahead": [
-        "keyword.join.sql",
-        "keyword.where.sql",
-        "keyword.group.sql",
-        "keyword.order.sql",
-        "keyword.select.limit.sql"
-      ],
+      "lookahead": 3,
+      "negativeLookahead": null,
       "recursive": false,
       "children": null,
       "end": null
@@ -924,15 +900,8 @@
         "entity.name.alias.sql"
       ],
       "type": "join",
-      "lookahead": 0,
-      "negativeLookahead": [
-        "keyword.join.sql",
-        "keyword.where.sql",
-        "keyword.group.sql",
-        "keyword.order.sql",
-        "keyword.select.limit.sql",
-        "keyword.expression.join.on.sql"
-      ],
+      "lookahead": 7,
+      "negativeLookahead": null,
       "recursive": false,
       "children": null,
       "end": null
@@ -949,15 +918,8 @@
         "entity.name.alias.sql"
       ],
       "type": "join",
-      "lookahead": 0,
-      "negativeLookahead": [
-        "keyword.join.sql",
-        "keyword.where.sql",
-        "keyword.group.sql",
-        "keyword.order.sql",
-        "keyword.select.limit.sql",
-        "keyword.expression.join.on.sql"
-      ],
+      "lookahead": 6,
+      "negativeLookahead": null,
       "recursive": false,
       "children": null,
       "end": null
@@ -973,15 +935,8 @@
         "entity.name.alias.sql"
       ],
       "type": "join",
-      "lookahead": 0,
-      "negativeLookahead": [
-        "keyword.join.sql",
-        "keyword.where.sql",
-        "keyword.group.sql",
-        "keyword.order.sql",
-        "keyword.select.limit.sql",
-        "keyword.expression.join.on.sql"
-      ],
+      "lookahead": 5,
+      "negativeLookahead": null,
       "recursive": false,
       "children": null,
       "end": null
@@ -996,15 +951,8 @@
         "entity.name.alias.sql"
       ],
       "type": "join",
-      "lookahead": 0,
-      "negativeLookahead": [
-        "keyword.join.sql",
-        "keyword.where.sql",
-        "keyword.group.sql",
-        "keyword.order.sql",
-        "keyword.select.limit.sql",
-        "keyword.expression.join.on.sql"
-      ],
+      "lookahead": 4,
+      "negativeLookahead": null,
       "recursive": false,
       "children": null,
       "end": null
@@ -1034,15 +982,8 @@
         "entity.name.alias.sql"
       ],
       "type": "join",
-      "lookahead": 0,
-      "negativeLookahead": [
-        "keyword.join.sql",
-        "keyword.where.sql",
-        "keyword.group.sql",
-        "keyword.order.sql",
-        "keyword.select.limit.sql",
-        "keyword.expression.join.on.sql"
-      ],
+      "lookahead": 4,
+      "negativeLookahead": null,
       "recursive": false,
       "children": ["join.on", "join.on.bracket"],
       "end": null
@@ -1056,15 +997,8 @@
         "entity.name.alias.sql"
       ],
       "type": "join",
-      "lookahead": 0,
-      "negativeLookahead": [
-        "keyword.join.sql",
-        "keyword.where.sql",
-        "keyword.group.sql",
-        "keyword.order.sql",
-        "keyword.select.limit.sql",
-        "keyword.expression.join.on.sql"
-      ],
+      "lookahead": 3,
+      "negativeLookahead": null,
       "recursive": false,
       "children": ["join.on", "join.on.bracket"],
       "end": null

--- a/server/src/linter/syntaxes/syntax.json
+++ b/server/src/linter/syntaxes/syntax.json
@@ -791,7 +791,13 @@
       ],
       "type": "from",
       "lookahead": 0,
-      "negativeLookahead": null,
+      "negativeLookahead": [
+        "keyword.join.sql",
+        "keyword.where.sql",
+        "keyword.group.sql",
+        "keyword.order.sql",
+        "keyword.select.limit.sql"
+      ],
       "recursive": false,
       "children": null,
       "end": null
@@ -807,7 +813,13 @@
       ],
       "type": "from",
       "lookahead": 0,
-      "negativeLookahead": null,
+      "negativeLookahead": [
+        "keyword.join.sql",
+        "keyword.where.sql",
+        "keyword.group.sql",
+        "keyword.order.sql",
+        "keyword.select.limit.sql"
+      ],
       "recursive": false,
       "children": null,
       "end": null
@@ -853,7 +865,13 @@
       ],
       "type": "from",
       "lookahead": 0,
-      "negativeLookahead": null,
+      "negativeLookahead": [
+        "keyword.join.sql",
+        "keyword.where.sql",
+        "keyword.group.sql",
+        "keyword.order.sql",
+        "keyword.select.limit.sql"
+      ],
       "recursive": false,
       "children": null,
       "end": null
@@ -868,21 +886,13 @@
       ],
       "type": "from",
       "lookahead": 0,
-      "negativeLookahead": null,
-      "recursive": false,
-      "children": null,
-      "end": null
-    },
-    {
-      "name": "from.dataset.object.no.alias",
-      "scopes": [
-        "keyword.from.sql",
-        "entity.name.dataset.sql",
-        "entity.name.object.sql"
+      "negativeLookahead": [
+        "keyword.join.sql",
+        "keyword.where.sql",
+        "keyword.group.sql",
+        "keyword.order.sql",
+        "keyword.select.limit.sql"
       ],
-      "type": "from",
-      "lookahead": 0,
-      "negativeLookahead": ["keyword.as.sql", "entity.name.alias.sql"],
       "recursive": false,
       "children": null,
       "end": null
@@ -915,7 +925,14 @@
       ],
       "type": "join",
       "lookahead": 0,
-      "negativeLookahead": null,
+      "negativeLookahead": [
+        "keyword.join.sql",
+        "keyword.where.sql",
+        "keyword.group.sql",
+        "keyword.order.sql",
+        "keyword.select.limit.sql",
+        "keyword.expression.join.on.sql"
+      ],
       "recursive": false,
       "children": null,
       "end": null
@@ -933,7 +950,14 @@
       ],
       "type": "join",
       "lookahead": 0,
-      "negativeLookahead": null,
+      "negativeLookahead": [
+        "keyword.join.sql",
+        "keyword.where.sql",
+        "keyword.group.sql",
+        "keyword.order.sql",
+        "keyword.select.limit.sql",
+        "keyword.expression.join.on.sql"
+      ],
       "recursive": false,
       "children": null,
       "end": null
@@ -950,7 +974,14 @@
       ],
       "type": "join",
       "lookahead": 0,
-      "negativeLookahead": null,
+      "negativeLookahead": [
+        "keyword.join.sql",
+        "keyword.where.sql",
+        "keyword.group.sql",
+        "keyword.order.sql",
+        "keyword.select.limit.sql",
+        "keyword.expression.join.on.sql"
+      ],
       "recursive": false,
       "children": null,
       "end": null
@@ -966,13 +997,35 @@
       ],
       "type": "join",
       "lookahead": 0,
-      "negativeLookahead": null,
+      "negativeLookahead": [
+        "keyword.join.sql",
+        "keyword.where.sql",
+        "keyword.group.sql",
+        "keyword.order.sql",
+        "keyword.select.limit.sql",
+        "keyword.expression.join.on.sql"
+      ],
       "recursive": false,
       "children": null,
       "end": null
     },
     {
-      "name": "join.no.project.explicit.alias",
+      "name": "join.no.alias",
+      "scopes": [
+        "keyword.join.sql",
+        "entity.name.project.sql",
+        "entity.name.dataset.sql",
+        "entity.name.object.sql"
+      ],
+      "type": "join",
+      "lookahead": 0,
+      "negativeLookahead": ["keyword.as.sql", "entity.name.alias.sql"],
+      "recursive": false,
+      "children": null,
+      "end": null
+    },
+    {
+      "name": "join.dataset.object.explicit.alias",
       "scopes": [
         "keyword.join.sql",
         "entity.name.dataset.sql",
@@ -982,13 +1035,20 @@
       ],
       "type": "join",
       "lookahead": 0,
-      "negativeLookahead": null,
+      "negativeLookahead": [
+        "keyword.join.sql",
+        "keyword.where.sql",
+        "keyword.group.sql",
+        "keyword.order.sql",
+        "keyword.select.limit.sql",
+        "keyword.expression.join.on.sql"
+      ],
       "recursive": false,
       "children": ["join.on", "join.on.bracket"],
       "end": null
     },
     {
-      "name": "join.no.project.implicit.alias",
+      "name": "join.dataset.object.implicit.alias",
       "scopes": [
         "keyword.join.sql",
         "entity.name.dataset.sql",
@@ -997,7 +1057,28 @@
       ],
       "type": "join",
       "lookahead": 0,
-      "negativeLookahead": null,
+      "negativeLookahead": [
+        "keyword.join.sql",
+        "keyword.where.sql",
+        "keyword.group.sql",
+        "keyword.order.sql",
+        "keyword.select.limit.sql",
+        "keyword.expression.join.on.sql"
+      ],
+      "recursive": false,
+      "children": ["join.on", "join.on.bracket"],
+      "end": null
+    },
+    {
+      "name": "join.dataset.object.no.alias",
+      "scopes": [
+        "keyword.join.sql",
+        "entity.name.dataset.sql",
+        "entity.name.object.sql"
+      ],
+      "type": "join",
+      "lookahead": 0,
+      "negativeLookahead": ["keyword.as.sql", "entity.name.alias.sql"],
       "recursive": false,
       "children": ["join.on", "join.on.bracket"],
       "end": null

--- a/server/src/linter/syntaxes/syntax.json
+++ b/server/src/linter/syntaxes/syntax.json
@@ -151,6 +151,20 @@
       "end": null
     },
     {
+      "name": "column.explicit.alias.missing",
+      "scopes": [
+        "entity.name.alias.sql",
+        "entity.other.column.sql",
+        "keyword.as.sql"
+      ],
+      "type": "column",
+      "lookahead": 3,
+      "negativeLookahead": ["entity.name.tag"],
+      "recursive": false,
+      "children": null,
+      "end": null
+    },
+    {
       "name": "column.explicit.alias.no.prefix",
       "scopes": [
         "entity.other.column.sql",

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -50,7 +50,7 @@ connection.onInitialize((params: InitializeParams) => {
 				resolveProvider: true
 			},
 			codeActionProvider: {
-				codeActionKinds: [CodeActionKind.QuickFix]
+				codeActionKinds: [CodeActionKind.QuickFix, CodeActionKind.SourceFixAll]
 			}
 		}
 	};

--- a/server/src/tests/linter/rules/aliasing/AL01.test.ts
+++ b/server/src/tests/linter/rules/aliasing/AL01.test.ts
@@ -42,6 +42,35 @@ describe('Table', () => {
         }]);
     });
 
+    it('should return codeaction when rule is enabled and as used', async () => {
+        instance.enabled = true;
+
+
+        const parser = new Parser();
+
+        const diagnostics = instance.evaluate(await parser.parse({text:'SELECT t.col1\n FROM dataset.table as t', uri: 'test.sql', languageId: 'sql', version: 0}));
+        const actions = instance.createCodeAction({uri: 'test.sql'}, diagnostics![0]);
+        expect(actions).to.deep.equal(instance.codeActionKind.map(kind => {
+            return {
+                title: instance.codeActionTitle, edit:{
+                changes: {
+                        ['test.sql']: [
+                            {
+                                newText: '',
+                                range: {
+                                    start: { line: 1, character: 19 },
+                                    end: { line: 1, character: 22 }
+                                }
+                            }
+                        ]
+                    }
+                },
+                kind: kind,
+                diagnostics: diagnostics
+            };
+        }));
+    });
+
     it('should return null when rule is enabled but pattern does not match', async () => {
         instance.enabled = true;
 

--- a/server/src/tests/linter/rules/aliasing/AL02.test.ts
+++ b/server/src/tests/linter/rules/aliasing/AL02.test.ts
@@ -42,6 +42,35 @@ describe('ColumnAlias', () => {
         }]);
     });
 
+    it('should return codeaction when rule is enabled and as used', async () => {
+        instance.enabled = true;
+
+
+        const parser = new Parser();
+
+        const diagnostics = instance.evaluate(await parser.parse({text:'SELECT t.col1 as c\n FROM dataset.table t', uri: 'test.sql', languageId: 'sql', version: 0}));
+        const actions = instance.createCodeAction({uri: 'test.sql'}, diagnostics![0]);
+        expect(actions).to.deep.equal(instance.codeActionKind.map(kind => {
+            return {
+                title: instance.codeActionTitle, edit:{
+                changes: {
+                        ['test.sql']: [
+                            {
+                                newText: '',
+                                range: {
+                                    start: { line: 0, character: 13 },
+                                    end: { line: 0, character: 16 }
+                                }
+                            }
+                        ]
+                    }
+                },
+                kind: kind,
+                diagnostics: diagnostics
+            };
+        }));
+    });
+
     it('should return null when rule is enabled but pattern does not match', async () => {
         instance.enabled = true;
 

--- a/server/src/tests/linter/rules/aliasing/AL05.test.ts
+++ b/server/src/tests/linter/rules/aliasing/AL05.test.ts
@@ -36,7 +36,7 @@ describe('UnusedAlias', () => {
             severity: instance.severity,
             range: {
                 start: { line: 0, character: 7 },
-                end: { line: 0, character: 11 }
+                end: { line: 0, character: 16 }
             },
             source: instance.source,
         }]);

--- a/server/src/tests/linter/rules/aliasing/AL06.test.ts
+++ b/server/src/tests/linter/rules/aliasing/AL06.test.ts
@@ -42,6 +42,26 @@ describe('TableAlias', () => {
         }]);
     });
 
+    it('should return diagnostic when rule is enabled and as used - join', async () => {
+        instance.enabled = true;
+
+
+        const parser = new Parser();
+
+        const result = instance.evaluate(await parser.parse({text:'SELECT t.col1 as c\n FROM dataset.table t\n inner join dataset.other_table\n;\n', uri: 'test.sql', languageId: 'sql', version: 0}));
+        expect(result).to.deep.equal([{
+            code: instance.diagnosticCode,
+            codeDescription: {href: instance.diagnosticCodeDescription},
+            message: instance.message,
+            severity: instance.severity,
+            range: {
+                start: { line: 2, character: 12 },
+                end: { line: 2, character: 31 }
+            },
+            source: instance.source,
+        }]);
+    });
+
     it('should return null when rule is enabled but pattern does not match', async () => {
         instance.enabled = true;
 

--- a/server/src/tests/linter/rules/aliasing/AL06.test.ts
+++ b/server/src/tests/linter/rules/aliasing/AL06.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @fileoverview Test suite for AL05
+ * module
+ */
+
+import { expect } from 'chai';
+import { defaultSettings } from '../../../../settings';
+import { TableAlias } from '../../../../linter/rules/aliasing/AL06';
+import { FileMap, Parser } from '../../../../linter/parser';
+import { StatementAST } from '../../../../linter/parser/ast';
+
+describe('TableAlias', () => {
+    let instance: TableAlias;
+
+    beforeEach(() => {
+        instance = new TableAlias(defaultSettings, 0);
+    });
+
+    it('should return null when rule is disabled', () => {
+        instance.enabled = false;
+        const result = instance.evaluate({1: new StatementAST()} as FileMap);
+        expect(result).to.be.null;
+    });
+
+    it('should return diagnostic when rule is enabled and as used', async () => {
+        instance.enabled = true;
+
+
+        const parser = new Parser();
+
+        const result = instance.evaluate(await parser.parse({text:'SELECT col1 as c\n FROM dataset.table\n;\n', uri: 'test.sql', languageId: 'sql', version: 0}));
+        expect(result).to.deep.equal([{
+            code: instance.diagnosticCode,
+            codeDescription: {href: instance.diagnosticCodeDescription},
+            message: instance.message,
+            severity: instance.severity,
+            range: {
+                start: { line: 1, character: 6 },
+                end: { line: 1, character: 19 }
+            },
+            source: instance.source,
+        }]);
+    });
+
+    it('should return null when rule is enabled but pattern does not match', async () => {
+        instance.enabled = true;
+
+        const parser = new Parser();
+
+        const result = instance.evaluate(await parser.parse({text:'SELECT t.col1 c\n FROM dataset.table t', uri: 'test.sql', languageId: 'sql', version: 0}));
+        expect(result).to.be.null;
+    });
+});

--- a/server/src/tests/linter/rules/aliasing/AL09.test.ts
+++ b/server/src/tests/linter/rules/aliasing/AL09.test.ts
@@ -27,7 +27,7 @@ describe('RedundantColumnAlias', () => {
 
         const parser = new Parser();
 
-        const result = instance.evaluate(await parser.parse({text:'SELECT col1 as col1,col2\n FROM table', uri: 'test.sql', languageId: 'sql', version: 0}));
+        const result = instance.evaluate(await parser.parse({text:'SELECT col1 as col1,\n       col2\n FROM table', uri: 'test.sql', languageId: 'sql', version: 0}));
         expect(result).to.deep.equal([{
             code: instance.diagnosticCode,
             codeDescription: {href: instance.diagnosticCodeDescription},

--- a/server/src/tests/linter/rules/aliasing/AL09.test.ts
+++ b/server/src/tests/linter/rules/aliasing/AL09.test.ts
@@ -42,6 +42,35 @@ describe('RedundantColumnAlias', () => {
         }]);
     });
 
+    it('should return codeaction when rule is enabled and as used', async () => {
+        instance.enabled = true;
+
+
+        const parser = new Parser();
+
+        const diagnostics = instance.evaluate(await parser.parse({text:'SELECT col1 as col1,\n       col2\n FROM table', uri: 'test.sql', languageId: 'sql', version: 0}));
+        const actions = instance.createCodeAction({uri: 'test.sql'}, diagnostics![0]);
+        expect(actions).to.deep.equal(instance.codeActionKind.map(kind => {
+            return {
+                title: instance.codeActionTitle, edit:{
+                changes: {
+                        ['test.sql']: [
+                            {
+                                newText: '',
+                                range: {
+                                    start: { line: 0, character: 11 },
+                                    end: { line: 0, character: 19 }
+                                }
+                            }
+                        ]
+                    }
+                },
+                kind: kind,
+                diagnostics: diagnostics
+            };
+        }));
+    });
+
     it('should return null when rule is enabled but pattern does not match', async () => {
         instance.enabled = true;
 

--- a/server/src/tests/linter/rules/aliasing/AL09.test.ts
+++ b/server/src/tests/linter/rules/aliasing/AL09.test.ts
@@ -34,7 +34,7 @@ describe('RedundantColumnAlias', () => {
             message: instance.message,
             severity: instance.severity,
             range: {
-                start: { line: 0, character: 15 },
+                start: { line: 0, character: 11 },
                 end: { line: 0, character: 19 }
             },
             source: instance.source,

--- a/server/src/tests/linter/rules/ambiguous/AM01.test.ts
+++ b/server/src/tests/linter/rules/ambiguous/AM01.test.ts
@@ -42,6 +42,35 @@ describe('Distinct', () => {
         }]);
     });
 
+    it('should return codeaction when rule is enabled and as used', async () => {
+        instance.enabled = true;
+
+
+        const parser = new Parser();
+
+        const diagnostics = instance.evaluate(await parser.parse({text:'SELECT distinct a.a\n  from dataset.table a\n group by a.a', uri: 'test.sql', languageId: 'sql', version: 0}));
+        const actions = instance.createCodeAction({uri: 'test.sql'}, diagnostics![0]);
+        expect(actions).to.deep.equal(instance.codeActionKind.map(kind => {
+            return {
+                title: instance.codeActionTitle, edit:{
+                changes: {
+                        ['test.sql']: [
+                            {
+                                newText: '',
+                                range: {
+                                    start: { line: 0, character: 6 },
+                                    end: { line: 0, character: 15 }
+                                }
+                            }
+                        ]
+                    }
+                },
+                kind: kind,
+                diagnostics: diagnostics
+            };
+        }));
+    });
+
     it('should return null when rule is enabled but pattern does not match', async () => {
         instance.enabled = true;
 

--- a/server/src/tests/linter/rules/ambiguous/AM04.test.ts
+++ b/server/src/tests/linter/rules/ambiguous/AM04.test.ts
@@ -23,7 +23,7 @@ describe('ColumnCount', () => {
         instance.enabled = true;
         const result = instance.evaluate('select * from table');
         const range = {
-            start: { line: 0, character: 0 },
+            start: { line: 0, character: 7 },
             end: { line: 0, character: 8 }
         };
         expect(result).to.deep.equal([{

--- a/server/src/tests/linter/rules/convention/CV02.test.ts
+++ b/server/src/tests/linter/rules/convention/CV02.test.ts
@@ -5,6 +5,7 @@
 import { expect } from 'chai';
 import { defaultSettings } from '../../../../settings';
 import { Coalesce } from '../../../../linter/rules/convention/CV02';
+import { Parser } from '../../../../linter/parser';
 
 describe('Coalesce', () => {
     let instance: Coalesce;
@@ -33,6 +34,33 @@ describe('Coalesce', () => {
             },
             source: instance.source
         }]);
+    });
+
+    it('should return codeaction when rule is enabled and as used', async () => {
+        instance.enabled = true;
+        const parser = new Parser();
+        await parser.parse({text:'select ifnull(a.col, b.col) from dataset.table a left join dataset.table b on a.col = b.col', uri: 'test.sql', languageId: 'sql', version: 0});
+        const diagnostics = instance.evaluate('select ifnull(a.col, b.col) from dataset.table a left join dataset.table b on a.col = b.col');
+        const actions = instance.createCodeAction({uri: 'test.sql'}, diagnostics![0]);
+        expect(actions).to.deep.equal(instance.codeActionKind.map(kind => {
+            return {
+                title: instance.codeActionTitle, edit:{
+                changes: {
+                        ['test.sql']: [
+                            {
+                                newText: 'coalesce',
+                                range: {
+                                    start: { line: 0, character: 7 },
+                                    end: { line: 0, character: 13 }
+                                }
+                            }
+                        ]
+                    }
+                },
+                kind: kind,
+                diagnostics: diagnostics
+            };
+        }));
     });
 
     it('should return null when rule is enabled but pattern does not match', () => {

--- a/server/src/tests/linter/rules/convention/CV02.test.ts
+++ b/server/src/tests/linter/rules/convention/CV02.test.ts
@@ -29,7 +29,7 @@ describe('Coalesce', () => {
             severity: instance.severity,
             range: {
                 start: { line: 0, character: 7 },
-                end: { line: 0, character: 14 }
+                end: { line: 0, character: 13 }
             },
             source: instance.source
         }]);

--- a/server/src/tests/linter/rules/convention/CV08.test.ts
+++ b/server/src/tests/linter/rules/convention/CV08.test.ts
@@ -5,6 +5,7 @@
 import { expect } from 'chai';
 import { defaultSettings } from '../../../../settings';
 import { LeftJoin } from '../../../../linter/rules/convention/CV08';
+import { Parser } from '../../../../linter/parser';
 
 describe('LeftJoin', () => {
     let instance: LeftJoin;
@@ -33,6 +34,33 @@ describe('LeftJoin', () => {
             },
             source: instance.source
         }]);
+    });
+
+    it('should return codeaction when rule is enabled and as used', async () => {
+        instance.enabled = true;
+        const parser = new Parser();
+        await parser.parse({text:'select a.col, b.col from dataset.table a right join dataset.table b on a.col = b.col', uri: 'test.sql', languageId: 'sql', version: 0});
+        const diagnostics = instance.evaluate('select a.col, b.col from dataset.table a right join dataset.table b on a.col = b.col');
+        const actions = instance.createCodeAction({uri: 'test.sql'}, diagnostics![0]);
+        expect(actions).to.deep.equal(instance.codeActionKind.map(kind => {
+            return {
+                title: instance.codeActionTitle, edit:{
+                changes: {
+                        ['test.sql']: [
+                            {
+                                newText: 'left join',
+                                range: {
+                                    start: { line: 0, character: 41 },
+                                    end: { line: 0, character: 51 }
+                                }
+                            }
+                        ]
+                    }
+                },
+                kind: kind,
+                diagnostics: diagnostics
+            };
+        }));
     });
 
     it('should return null when rule is enabled but pattern does not match', () => {

--- a/server/src/tests/linter/rules/layout/LT01.test.ts
+++ b/server/src/tests/linter/rules/layout/LT01.test.ts
@@ -5,8 +5,7 @@
 import { expect } from 'chai';
 import { defaultSettings } from '../../../../settings';
 import { TrailingSpaces } from '../../../../linter/rules/layout/LT01';
-import { FileMap, Parser } from '../../../../linter/parser';
-import { StatementAST } from '../../../../linter/parser/ast';
+import { Parser } from '../../../../linter/parser';
 
 describe('TrailingSpaces', () => {
     let instance: TrailingSpaces;

--- a/server/src/tests/linter/rules/layout/LT01.test.ts
+++ b/server/src/tests/linter/rules/layout/LT01.test.ts
@@ -1,11 +1,12 @@
 /**
- * @fileoverview Test suite for LT11 module
+ * @fileoverview Test suite for LT04 module
  */
 
 import { expect } from 'chai';
 import { defaultSettings } from '../../../../settings';
 import { TrailingSpaces } from '../../../../linter/rules/layout/LT01';
-import { runInThisContext } from 'vm';
+import { FileMap, Parser } from '../../../../linter/parser';
+import { StatementAST } from '../../../../linter/parser/ast';
 
 describe('TrailingSpaces', () => {
     let instance: TrailingSpaces;
@@ -14,93 +15,83 @@ describe('TrailingSpaces', () => {
         instance = new TrailingSpaces(defaultSettings, 0);
     });
 
-    it('Case 1: should return null when rule is disabled', () => {
+    it('should return null when rule is disabled', () => {
         instance.enabled = false;
-        const result = instance.evaluate('test');
+        const result = instance.evaluate('', 'test.sql');
         expect(result).to.be.null;
     });
 
-    const listSql: string[][] = [
-        ['Case 2: trailing spaces',
-        `select * \n
-        from tablename`,'0','8',
-    '0','9'],
- 
-    ];
+    it('should return diagnostic when rule is enabled and triggered - EOL', async () => {
+        instance.enabled = true;
 
-    listSql.forEach((element: string[]) => {
-        it(`${element[0]}\nshould return diagnostic when rule is enabled and pattern matches`, () => {
-            instance.enabled = true;
-            const result = instance.evaluate(element[1]);
-            expect(result).to.deep.equal([{
-                code: instance.diagnosticCode,
+
+        const result = instance.evaluate('SELECT t.col1  \n FROM dataset.TrailingSpaces as t', 'test.sql');
+        expect(result).to.deep.equal([{
+            code: instance.diagnosticCode,
             codeDescription: {href: instance.diagnosticCodeDescription},
             message: instance.message,
-                severity: instance.severity,
-                range: {
-                    start: { line: parseInt(element[2]), character: parseInt(element[3]) },
-                    end: { line: parseInt(element[4]), character: parseInt(element[5]) }
-                },
-                source: instance.source
-            }]);
-        });
+            severity: instance.severity,
+            range: {
+                start: { line: 0, character: 13 },
+                end: { line: 0, character: 15 }
+            },
+            source: instance.source,
+        }]);
     });
 
-    const listSQLMultipleErrors: string[][] = [
+    it('should return diagnostic when rule is enabled and triggered - parenthesis', async () => {
+        instance.enabled = true;
 
 
-        ['Case 3: multiple errors',
-        `select * \n
-         from tablename\nselect
-         * \nfrom tablename`,'0','8','0','9','4','10','4','11'],];
-
-
-
-          listSQLMultipleErrors.forEach((element: string[]) => {
-            it(`${element[0]}\nshould return diagnostic when rule is enabled and pattern matches`, () => {
-                instance.enabled = true;
-                const result = instance.evaluate(element[1]);
-                expect(result).to.deep.equal([{
-                    code: instance.diagnosticCode,
+        const result = instance.evaluate('SELECT t.col1\n cast(t.col2 as string  ) FROM dataset.TrailingSpaces as t', 'test.sql');
+        expect(result).to.deep.equal([{
+            code: instance.diagnosticCode,
             codeDescription: {href: instance.diagnosticCodeDescription},
             message: instance.message,
-                    severity: instance.severity,
-                    range: {
-                        start: { line: parseInt(element[2]), character: parseInt(element[3]) },
-                        end: { line: parseInt(element[4]), character: parseInt(element[5]) }
-                    },
-                    source: instance.source
-                },{
-                    code: instance.diagnosticCode,
-            codeDescription: {href: instance.diagnosticCodeDescription},
-            message: instance.message,
-                    severity: instance.severity,
-                    range: {
-                        start: { line: parseInt(element[6]), character: parseInt(element[7]) },
-                        end: { line: parseInt(element[8]), character: parseInt(element[9]) }
-                    },
-                    source: instance.source
-                }]);
-            });
-        });
+            severity: instance.severity,
+            range: {
+                start: { line: 1, character: 22 },
+                end: { line: 1, character: 24 }
+            },
+            source: instance.source,
+        }]);
+    });
 
-    const listSqlMultiples: string[][] = [
-        ['Case 4: multiple errors',
-        `select * \n
-        from tablename\nselect
-        * \nfrom tablename`],
-    ];
+    it('should return codeaction when rule is enabled and as used', async () => {
+        instance.enabled = true;
 
-    const listSqlNoMatch: string[][] = [
-        ['Case 5: pattern does not match (union all)',
-        `select *\nfrom table`],
-    ];
 
-    listSqlNoMatch.forEach((element: string[]) => {
-        it(`${element[0]}\nshould return null when rule is enabled but pattern does not match`, () => {
-            instance.enabled = true;
-            const result = instance.evaluate(element[1]);
-            expect(result).to.be.null;
-        });
+        const parser = new Parser();
+        await parser.parse({text:'SELECT t.col1  \n FROM dataset.TrailingSpaces as t', uri: 'test.sql', languageId: 'sql', version: 0});
+        const diagnostics = instance.evaluate('SELECT t.col1  \n FROM dataset.TrailingSpaces as t');
+        const actions = instance.createCodeAction({uri: 'test.sql'}, diagnostics![0]);
+        expect(actions).to.deep.equal(instance.codeActionKind.map(kind => {
+            return {
+                title: instance.codeActionTitle, edit:{
+                changes: {
+                        ['test.sql']: [
+                            {
+                                newText: '',
+                                range: {
+                                    start: { line: 0, character: 13 },
+                                    end: { line: 0, character: 15 }
+                                }
+                            }
+                        ]
+                    }
+                },
+                kind: kind,
+                diagnostics: diagnostics
+            };
+        }));
+    });
+
+    it('should return null when rule is enabled but pattern does not match', async () => {
+        instance.enabled = true;
+
+        const parser = new Parser();
+
+        const result = instance.evaluate('SELECT t.col1\n FROM dataset.TrailingSpaces t');
+        expect(result).to.be.null;
     });
 });

--- a/server/src/tests/linter/rules/layout/LT01.test.ts
+++ b/server/src/tests/linter/rules/layout/LT01.test.ts
@@ -91,14 +91,6 @@ describe('TrailingSpaces', () => {
         * \nfrom tablename`],
     ];
 
-    listSqlMultiples.forEach((element: string[]) => {
-        it(`${element[0]}\nshould return number of matches greater than 1 when rule is enabled and pattern matches more than once`, () => {
-            instance.enabled = true;
-            const noOfMatches = instance.matches(element[1]);
-            expect(noOfMatches).to.be.greaterThan(1);
-        });
-    });
-
     const listSqlNoMatch: string[][] = [
         ['Case 5: pattern does not match (union all)',
         `select *\nfrom table`],

--- a/server/src/tests/linter/rules/layout/LT06.test.ts
+++ b/server/src/tests/linter/rules/layout/LT06.test.ts
@@ -41,6 +41,34 @@ describe('Functions', () => {
         }]);
     });
 
+    it('should return codeaction when rule is enabled and as used', async () => {
+        instance.enabled = true;
+
+
+        const parser = new Parser();
+        const diagnostics = instance.evaluate(await parser.parse({text:'SELECT cast (1 as string),\n col2\n FROM table', uri: 'test.sql', languageId: 'sql', version: 0}));
+        const actions = instance.createCodeAction({uri: 'test.sql'}, diagnostics![0]);
+        expect(actions).to.deep.equal(instance.codeActionKind.map(kind => {
+            return {
+                title: instance.codeActionTitle, edit:{
+                changes: {
+                        ['test.sql']: [
+                            {
+                                newText: '',
+                                range: {
+                                    start: { line: 0, character: 11 },
+                                    end: { line: 0, character: 12 }
+                                }
+                            }
+                        ]
+                    }
+                },
+                kind: kind,
+                diagnostics: diagnostics
+            };
+        }));
+    });
+
     it('should return null when rule is enabled but pattern does not match', async () => {
         instance.enabled = true;
 

--- a/server/src/tests/linter/rules/layout/LT10.test.ts
+++ b/server/src/tests/linter/rules/layout/LT10.test.ts
@@ -43,7 +43,7 @@ describe('SelectModifiers', () => {
         `select   \n      <modifier> column from tablename`,'1','6'],
 
         ['modifier not on same line as select and multiple new lines before modifier (modifier: <modifier>)',
-        `select \n\n\n<modifier> column from tablename`,'3','0']
+        `select \n\n\n<modifier> column from tablename`,'3', '0'],
     ];
     
 
@@ -53,8 +53,10 @@ describe('SelectModifiers', () => {
             case_number++;
             const new_title: string = element[0].replace('<modifier>', mod);
             const new_sql: string = element[1].replace('<modifier>', mod);
-            const expected_line: number = parseInt(element[2]);
-            const expected_character: number = parseInt(element[3]) + mod.length;
+            const start_line: number = parseInt(element[2]);
+            const start_character: number = parseInt(element[3]);
+            const end_line: number = parseInt(element[2]);
+            const end_character: number = parseInt(element[3]) + mod.length;
 
             it(`Case ${case_number}: ${new_title}\nshould return diagnostic when rule is enabled and pattern matches`, () => {
                 instance.enabled = true;
@@ -65,8 +67,8 @@ describe('SelectModifiers', () => {
             message: instance.message,
                     severity: instance.severity,
                     range: {
-                        start: { line: 0, character: 0 },
-                        end: { line: expected_line, character: expected_character }
+                        start: { line: start_line, character: start_character },
+                        end: { line: end_line, character: end_character }
                     },
                     source: instance.source
                 }]);

--- a/server/src/tests/linter/rules/layout/LT11.test.ts
+++ b/server/src/tests/linter/rules/layout/LT11.test.ts
@@ -1,193 +1,75 @@
 /**
- * @fileoverview Test suite for LT11 module
+ * @fileoverview Test suite for LT12 module
  */
 
 import { expect } from 'chai';
 import { defaultSettings } from '../../../../settings';
 import { UnionCheck } from '../../../../linter/rules/layout/LT11';
-import { runInThisContext } from 'vm';
 
 describe('UnionCheck', () => {
-    let instance: UnionCheck;
+		let instance: UnionCheck;
 
-    beforeEach(() => {
-        instance = new UnionCheck(defaultSettings, 0);
-    });
+		beforeEach(() => {
+				instance = new UnionCheck(defaultSettings, 0);
+		});
 
-    it('Case 1: should return null when rule is disabled', () => {
-        instance.enabled = false;
-        const result = instance.evaluate('test');
-        expect(result).to.be.null;
-    });
+		it('should return null when rule is disabled', () => {
+				instance.enabled = false;
+				const result = instance.evaluate('test');
+				expect(result).to.be.null;
+		});
 
-    const listSql: string[][] = [
-        ['Case 2: no new line on left (union all)',
-        `select *
-        from tablename\n union all\nselect
-        * from tablename`,'2','1',
-    '2','10'],
+		it('should return diagnostic when rule is enabled and pattern does not match - trailing', () => {
+				instance.enabled = true;
+				const result = instance.evaluate('select t.col\n  from dataset.table t\nunion all select t.col\n  from dataset.table t');
+				expect(result).to.deep.equal([{
+						code: instance.diagnosticCode,
+                        codeDescription: {href: instance.diagnosticCodeDescription},
+						message: instance.message,
+						severity: instance.severity,
+						range: {
+								start: { line: 2, character: 0 },
+								end: { line: 2, character: 10 }
+						},
+						source: instance.source
+				}]);
+		});
 
-        ['Case 3: no new line on right (union all)',
-        `select *
-        from tablename\nunion all \nselect
-        * from tablename`,'2','0','2','9'],
+		it('should return diagnostic when rule is enabled and pattern does not match - leading', () => {
+				instance.enabled = true;
+				const result = instance.evaluate('select t.col\n  from dataset.table t union all\nselect t.col\n  from dataset.table t');
+				expect(result).to.deep.equal([{
+						code: instance.diagnosticCode,
+                        codeDescription: {href: instance.diagnosticCodeDescription},
+						message: instance.message,
+						severity: instance.severity,
+						range: {
+								start: { line: 1, character: 22 },
+								end: { line: 1, character: 32 }
+						},
+						source: instance.source
+				}]);
+		});
 
-        ['Case 4: no new line on either side (union all)',
-        `select *
-         from tablename\n union all \nselect
-         * from tablename`,'2','1','2','10'],
+		it('should return diagnostic when rule is enabled and pattern does not match - both', () => {
+				instance.enabled = true;
+				const result = instance.evaluate('select t.col\n  from dataset.table t union all select t.col\n  from dataset.table t');
+				expect(result).to.deep.equal([{
+						code: instance.diagnosticCode,
+                        codeDescription: {href: instance.diagnosticCodeDescription},
+						message: instance.message,
+						severity: instance.severity,
+						range: {
+								start: { line: 1, character: 22 },
+								end: { line: 1, character: 32 }
+						},
+						source: instance.source
+				}]);
+		});
 
-       ['Case 6: no new line on left (union distinct)',
-       `select *
-        from tablename\n union distinct\nselect
-        * from tablename`, '2','1','2','15'],
-
-        ['Case 7: no new line on right (union distinct)',
-        `select *
-         from tablename\nunion distinct \nselect
-         * from tablename`, '2','0','2','14'],
-
-         ['Case 8: no new line on either side (union distinct)',
-         `select *
-         from tablename\n union distinct \nselect
-         * from tablename`, '2','1','2','15'],
- 
-         ['Case 10: no new line on left (union)',
-         `select *
-          from tablename\n union\nselect
-          * from tablename`, '2','1','2','6'],
- 
-        ['Case 11: no new line on right (union)',
-         `select *
-          from tablename\nunion \nselect
-          * from tablename`, '2','0','2','5'],
- 
-        ['Case 12: no new line on either side (union)',
-         `select *
-         from tablename\n union \nselect
-         * from tablename`, '2','1','2','6'],
- 
-    ];
-
-    listSql.forEach((element: string[]) => {
-        it(`${element[0]}\nshould return diagnostic when rule is enabled and pattern matches`, () => {
-            instance.enabled = true;
-            const result = instance.evaluate(element[1]);
-            expect(result).to.deep.equal([{
-                code: instance.diagnosticCode,
-            codeDescription: {href: instance.diagnosticCodeDescription},
-            message: instance.message,
-                severity: instance.severity,
-                range: {
-                    start: { line: parseInt(element[2]), character: parseInt(element[3]) },
-                    end: { line: parseInt(element[4]), character: parseInt(element[5]) }
-                },
-                source: instance.source
-            }]);
-        });
-    });
-
-    const listSQLMultipleErrors: string[][] = [
-
-
-        ['Case 5: multiple errors (union all)',
-        `select *
-         from tablename\nunion all \nselect
-         * from tablename\n union all\nselect
-         * from tablename`,'2','0','2','9','5','1','5','10'],
-
-        ['Case 9: multiple errors (union distinct)',
-         `select *
-          from tablename\nunion distinct \nselect
-          * from tablename\n union distinct\nselect
-          * from tablename`, '2','0','2','14','5','1','5','15'],
-       
-        ['Case 13: multiple errors (union)',
-         `select *
-          from tablename\nunion \nselect
-          * from tablename\n union\nselect
-          * from tablename`, '2','0','2','5','5','1','5','6']];
-
-
-
-          listSQLMultipleErrors.forEach((element: string[]) => {
-            it(`${element[0]}\nshould return diagnostic when rule is enabled and pattern matches`, () => {
-                instance.enabled = true;
-                const result = instance.evaluate(element[1]);
-                expect(result).to.deep.equal([{
-                    code: instance.diagnosticCode,
-            codeDescription: {href: instance.diagnosticCodeDescription},
-            message: instance.message,
-                    severity: instance.severity,
-                    range: {
-                        start: { line: parseInt(element[2]), character: parseInt(element[3]) },
-                        end: { line: parseInt(element[4]), character: parseInt(element[5]) }
-                    },
-                    source: instance.source
-                },{
-                    code: instance.diagnosticCode,
-            codeDescription: {href: instance.diagnosticCodeDescription},
-            message: instance.message,
-                    severity: instance.severity,
-                    range: {
-                        start: { line: parseInt(element[6]), character: parseInt(element[7]) },
-                        end: { line: parseInt(element[8]), character: parseInt(element[9]) }
-                    },
-                    source: instance.source
-                }]);
-            });
-        });
-
-    const listSqlMultiples: string[][] = [
-        ['Case 14: multiple errors (union all)',
-        `select *
-         from tablename\nunion all \nselect
-         * from tablename\n union all\nselect
-         * from tablename`],
-
-        ['Case 15: multiple errors (union distinct)',
-        `select *
-         from tablename\nunion distinct \nselect
-         * from tablename\n union distinct\nselect
-         * from tablename`],
-         
-        ['Case 16: multiple errors (union distinct)',
-        `select *
-         from tablename\nunion distinct \nselect
-         * from tablename\n union distinct\nselect
-         * from tablename`],
-    ];
-
-    listSqlMultiples.forEach((element: string[]) => {
-        it(`${element[0]}\nshould return number of matches greater than 1 when rule is enabled and pattern matches more than once`, () => {
-            instance.enabled = true;
-            const noOfMatches = instance.matches(element[1]);
-            expect(noOfMatches).to.be.greaterThan(1);
-        });
-    });
-
-    const listSqlNoMatch: string[][] = [
-        ['Case 17: pattern does not match (union all)',
-        `select something_union
-         from tablename\nunion all\nselect
-         * from tablename`],
-
-        ['Case 18: pattern does not match (union distinct)',
-        `select something_union
-         from tablename\nunion distinct\nselect
-         * from tablename`],
-         
-        ['Case 19: pattern does not match (union)',
-        `select something_union
-         from tablename\nunion\nselect
-         * from tablename`],
-    ];
-
-    listSqlNoMatch.forEach((element: string[]) => {
-        it(`${element[0]}\nshould return null when rule is enabled but pattern does not match`, () => {
-            instance.enabled = true;
-            const result = instance.evaluate(element[1]);
-            expect(result).to.be.null;
-        });
-    });
+		it('should return null when rule is enabled but pattern does not match', () => {
+				instance.enabled = true;
+				const result = instance.evaluate('select t.col\n  from dataset.table t\nunion all\nselect t.col\n  from dataset.table t');
+				expect(result).to.be.null;
+		});
 });

--- a/server/src/tests/linter/rules/layout/LT12.test.ts
+++ b/server/src/tests/linter/rules/layout/LT12.test.ts
@@ -5,6 +5,7 @@
 import { expect } from 'chai';
 import { defaultSettings } from '../../../../settings';
 import { EndofFile } from '../../../../linter/rules/layout/LT12';
+import { Parser } from '../../../../linter/parser';
 
 describe('EndofFile', () => {
 		let instance: EndofFile;
@@ -34,6 +35,35 @@ describe('EndofFile', () => {
 						source: instance.source
 				}]);
 		});
+
+    it('should return codeaction when rule is enabled and as used', async () => {
+        instance.enabled = true;
+
+
+        const parser = new Parser();
+        await parser.parse({text:'select *\n  from table', uri: 'test.sql', languageId: 'sql', version: 0});
+        const diagnostics = instance.evaluate('select *\n  from table');
+        const actions = instance.createCodeAction({uri: 'test.sql'}, diagnostics![0]);
+        expect(actions).to.deep.equal(instance.codeActionKind.map(kind => {
+            return {
+                title: instance.codeActionTitle, edit:{
+                changes: {
+                        ['test.sql']: [
+                            {
+                                newText: '\n',
+                                range: {
+                                    start: { line: 1, character: 11 },
+                                    end: { line: 1, character: 11 }
+                                }
+                            }
+                        ]
+                    }
+                },
+                kind: kind,
+                diagnostics: diagnostics
+            };
+        }));
+    });
 
 		it('should return null when rule is enabled but pattern does not match', () => {
 				instance.enabled = true;

--- a/server/src/tests/linter/rules/layout/LT12.test.ts
+++ b/server/src/tests/linter/rules/layout/LT12.test.ts
@@ -28,8 +28,8 @@ describe('EndofFile', () => {
 						message: instance.message,
 						severity: instance.severity,
 						range: {
-								start: { line: 2, character: 12 },
-								end: { line: 2, character: 12 }
+								start: { line: 1, character: 11 },
+								end: { line: 1, character: 11 }
 						},
 						source: instance.source
 				}]);

--- a/server/src/tests/linter/rules/structure/ST01.test.ts
+++ b/server/src/tests/linter/rules/structure/ST01.test.ts
@@ -28,8 +28,8 @@ describe('ElseNull', () => {
             message: instance.message,
             severity: instance.severity,
             range: {
-                start: { line: 0, character: 33 },
-                end: { line: 0, character: 42 }
+                start: { line: 0, character: 32 },
+                end: { line: 0, character: 43 }
             },
             source: instance.source,
             tags: [1]

--- a/server/src/tests/linter/rules/structure/ST01.test.ts
+++ b/server/src/tests/linter/rules/structure/ST01.test.ts
@@ -5,6 +5,7 @@
 import { expect } from 'chai';
 import { defaultSettings } from '../../../../settings';
 import { ElseNull } from '../../../../linter/rules/structure/ST01';
+import { Parser } from '../../../../linter/parser';
 
 describe('ElseNull', () => {
     let instance: ElseNull;
@@ -34,6 +35,35 @@ describe('ElseNull', () => {
             source: instance.source,
             tags: [1]
         }]);
+    });
+
+    it('should return codeaction when rule is enabled and as used', async () => {
+        instance.enabled = true;
+
+
+        const parser = new Parser();
+        await parser.parse({text:'select case when col1 = 1 then 2 else null end col from table', uri: 'test.sql', languageId: 'sql', version: 0});
+        const diagnostics = instance.evaluate('select case when col1 = 1 then 2 else null end col from table');
+        const actions = instance.createCodeAction({uri: 'test.sql'}, diagnostics![0]);
+        expect(actions).to.deep.equal(instance.codeActionKind.map(kind => {
+            return {
+                title: instance.codeActionTitle, edit:{
+                changes: {
+                        ['test.sql']: [
+                            {
+                                newText: '',
+                                range: {
+                                    start: { line: 0, character: 32 },
+                                    end: { line: 0, character: 43 }
+                                }
+                            }
+                        ]
+                    }
+                },
+                kind: kind,
+                diagnostics: diagnostics
+            };
+        }));
     });
 
     it('should return null when rule is enabled but pattern does not match', () => {

--- a/server/src/tests/linter/rules/structure/ST07.test.ts
+++ b/server/src/tests/linter/rules/structure/ST07.test.ts
@@ -28,7 +28,7 @@ describe('Using', () => {
             message: instance.message,
             severity: instance.severity,
             range: {
-                start: { line: 0, character: 32 },
+                start: { line: 0, character: 53 },
                 end: { line: 0, character: 58 }
             },
             source: instance.source

--- a/server/src/tests/linter/rules/structure/ST08.test.ts
+++ b/server/src/tests/linter/rules/structure/ST08.test.ts
@@ -28,7 +28,7 @@ describe('Distinct', () => {
             message: instance.message,
             severity: instance.severity,
             range: {
-                start: { line: 0, character: 0 },
+                start: { line: 0, character: 7 },
                 end: { line: 0, character: 18 }
             },
             source: instance.source


### PR DESCRIPTION
This pull request introduces several enhancements, including the addition of a `is_fix_compatible` property to multiple rule classes, enabling support for quick fixes in the linter. Additionally, the setup script has been updated to include the installation of Sphinx, ensuring that the documentation generation tool is readily available for use. These changes aim to improve the overall functionality and usability of the linter.