### PR TITLE
Add NotEqual rule to enforce usage of `!=` over `<>` in SQL queries

### DIFF
--- a/server/src/linter/rules/convention/CV01.ts
+++ b/server/src/linter/rules/convention/CV01.ts
@@ -1,0 +1,83 @@
+import { ServerSettings } from "../../../settings";
+import { CodeAction, CodeActionKind, Diagnostic, DiagnosticSeverity, TextDocumentIdentifier, TextEdit } from 'vscode-languageserver/node';
+import { Rule } from '../base';
+
+
+/**
+ * The NotEqual rule
+ * @class NotEqual
+ * @extends Rule
+ * @memberof Linter.Rules
+ */
+export class NotEqual extends Rule<string> {
+  readonly name: string = "not_equal";
+  readonly code: string = "CV01";
+  readonly message: string = "Use `!=` instead of `<>.";
+	readonly relatedInformation: string = ".";
+  readonly pattern: RegExp = /<>/gmi;
+  readonly severity: DiagnosticSeverity = DiagnosticSeverity.Warning;
+  readonly ruleGroup: string = 'convention';
+  readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
+  readonly codeActionTitle = 'Replace with `!=`';
+
+  /**
+   * Creates an instance of NotEqual.
+   * @param {ServerSettings} settings The server settings
+   * @param {number} problems The number of problems identified in the source code
+   * @memberof NotEqual
+   */
+  constructor(settings: ServerSettings, problems: number) {
+    super(settings, problems);
+  }
+
+  /**
+   * Evaluates the given test string against a pattern and returns diagnostics if the pattern matches.
+   *
+   * @param test - The string to be tested against the pattern.
+   * @param documentUri - The URI of the document being evaluated, optional.
+   * @returns An array of diagnostics if the pattern matches, otherwise null.
+   */
+  evaluate(test: string, documentUri: string | null = null): Diagnostic[] | null {
+
+    if (this.enabled === false) {
+      return null;
+    }
+
+    if (this.pattern.test(test)) {
+      return this.evaluateMultiRegexTest(test, documentUri);
+    }
+
+    return null;
+
+  }
+  
+  /**
+   * Creates a set of code actions to fix diagnostics.
+   *
+   * @param textDocument - The identifier of the text document where the diagnostic was reported.
+   * @param diagnostic - The diagnostic information about the issue to be fixed.
+   * @returns An array of code actions that can be applied to fix the issue.
+   */
+  createCodeAction(textDocument: TextDocumentIdentifier, diagnostic: Diagnostic): CodeAction[] {
+    const edit = {
+        changes: {
+            [textDocument.uri]: [
+                TextEdit.replace(diagnostic.range, '!=')
+            ]
+        }
+    };
+    const actions: CodeAction[] = [];
+    
+    this.codeActionKind.map((kind) => {
+      const fix = CodeAction.create(
+        this.codeActionTitle,
+        edit,
+        kind
+      );
+      fix.diagnostics = [diagnostic];
+      actions.push(fix);
+    });
+
+    return actions;
+  }
+}

--- a/server/src/linter/rules/convention/rules.ts
+++ b/server/src/linter/rules/convention/rules.ts
@@ -8,11 +8,13 @@
 
 import { Rule } from '../base';
 import { ServerSettings } from '../../../settings';
+import { NotEqual } from './CV01';
 import { Coalesce } from './CV02';
 import { LeftJoin } from './CV08';
 import { FileMap } from '../../parser';
 
-export const classes = [Coalesce,
+export const classes = [NotEqual,
+												Coalesce,
 												LeftJoin];
 
 export function conventionRules(settings: ServerSettings, problems: number): Rule<string | FileMap>[] {

--- a/server/src/tests/linter/rules/convention/CV01.test.ts
+++ b/server/src/tests/linter/rules/convention/CV01.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @fileoverview Test suite for LT13 module
+ */
+
+import { expect } from 'chai';
+import { defaultSettings } from '../../../../settings';
+import { NotEqual } from '../../../../linter/rules/convention/CV01';
+import { Parser } from '../../../../linter/parser';
+
+describe('NotEqual', () => {
+    let instance: NotEqual;
+
+    beforeEach(() => {
+        instance = new NotEqual(defaultSettings, 0);
+    });
+
+    it('should return null when rule is disabled', () => {
+        instance.enabled = false;
+        const result = instance.evaluate('test');
+        expect(result).to.be.null;
+    });
+
+    it('should return diagnostic when rule is enabled and pattern matches', () => {
+        instance.enabled = true;
+        const result = instance.evaluate('select a.col, b.col from dataset.table a left join dataset.table b on a.col <> b.col');
+        expect(result).to.deep.equal([{
+            code: instance.diagnosticCode,
+            codeDescription: {href: instance.diagnosticCodeDescription},
+            message: instance.message,
+            severity: instance.severity,
+            range: {
+                start: { line: 0, character: 76 },
+                end: { line: 0, character: 78 }
+            },
+            source: instance.source
+        }]);
+    });
+
+    it('should return codeaction when rule is enabled and as used', async () => {
+        instance.enabled = true;
+        const parser = new Parser();
+        await parser.parse({text:'select a.col, b.col from dataset.table a left join dataset.table b on a.col <> b.col', uri: 'test.sql', languageId: 'sql', version: 0});
+        const diagnostics = instance.evaluate('select a.col, b.col from dataset.table a left join dataset.table b on a.col <> b.col');
+        const actions = instance.createCodeAction({uri: 'test.sql'}, diagnostics![0]);
+        expect(actions).to.deep.equal(instance.codeActionKind.map(kind => {
+            return {
+                title: instance.codeActionTitle, edit:{
+                changes: {
+                        ['test.sql']: [
+                            {
+                                newText: '!=',
+                                range: {
+                                    start: { line: 0, character: 76 },
+                                    end: { line: 0, character: 78 }
+                                }
+                            }
+                        ]
+                    }
+                },
+                kind: kind,
+                diagnostics: diagnostics
+            };
+        }));
+    });
+
+    it('should return null when rule is enabled but pattern does not match', () => {
+        instance.enabled = true;
+        const result = instance.evaluate('select NotEqual(a.col, b.col) from dataset.table a left join dataset.table b on a.col = b.col');
+        expect(result).to.be.null;
+    });
+});


### PR DESCRIPTION
This pull request introduces a new linting rule, `NotEqual`, which enforces the use of `!=` instead of `<>` in SQL queries. The rule provides diagnostics when the deprecated operator is detected and offers a code action to replace it automatically. Additionally, unit tests have been added to ensure the rule functions correctly under various scenarios, including when the rule is enabled or disabled and when the pattern matches or does not match. This enhancement aims to improve code consistency and adherence to modern SQL standards.