### PR TITLE
Add SQL rule for unique table aliases (AL04)

### DIFF
--- a/docs/source/rules/convention/CV01.rst
+++ b/docs/source/rules/convention/CV01.rst
@@ -1,0 +1,56 @@
+=================================
+Rule: Use `!=` Not `<>`
+=================================
+
+**Rule Code:** ``CV01``
+
+**Name:** ``not_equal``
+
+Overview
+--------
+
+In SQL, both `!=` and `<>` can be used as operators to represent "not equal to." However, it is recommended to use `!=` instead of `<>` for consistency and readability. The `!=` operator is more commonly used and widely recognized in modern SQL syntax across different database systems, making it the preferred choice. Consistently using `!=` aligns with conventional coding practices, improving code readability and uniformity across queries.
+
+Explanation
+-----------
+
+Anti-pattern: Using `<>` for Not Equal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The `<>` operator is a valid way to express "not equal to" in SQL, but it is less commonly used compared to `!=`. Using `<>` can lead to inconsistencies in code, especially when some queries use `!=` and others use `<>`. This lack of uniformity can cause confusion and reduce the readability of the SQL code.
+
+**Example of Using `<>` for Not Equal (Anti-pattern):**
+
+.. code-block:: sql
+
+    SELECT *
+    FROM orders
+    WHERE status <> 'shipped';
+
+In this example, the `<>` operator is used to check if the `status` column is not equal to `'shipped'`. While this is valid syntax, it is less commonly used and can lead to inconsistencies in SQL coding style.
+
+Best Practice: Use `!=` for Not Equal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For consistency and clarity, it is recommended to use `!=` instead of `<>`. The `!=` operator is more widely recognized and consistent with modern SQL conventions. This ensures that the SQL code is easy to read and maintain, especially in teams with multiple developers.
+
+**Refactored Example Using `!=` (Best Practice):**
+
+.. code-block:: sql
+
+    SELECT *
+    FROM orders
+    WHERE status != 'shipped';
+
+In this refactored example, the `!=` operator is used, providing clearer, more consistent syntax for expressing "not equal to."
+
+Conclusion
+----------
+
+Using `!=` instead of `<>` ensures that SQL queries are consistent, readable, and adhere to modern conventions. Following this rule reduces ambiguity and makes the SQL code easier to understand and maintain across various database systems.
+
+Groups:
+-------
+
+- `all <../..>`_
+- `convention <../..#convention-rules>`_

--- a/docs/source/rules/index.rst
+++ b/docs/source/rules/index.rst
@@ -33,6 +33,7 @@ Ambiguous rules are guidelines that help developers avoid ambiguity and improve 
 .. toctree::
 	:maxdepth: 1
 
+	Rule: Do Not Use `DISTINCT` with `GROUP BY` <ambiguous/AM01>
 	Rule: Avoid Using `SELECT *` <ambiguous/AM04>
 
 .. _capitalisation-rules:
@@ -61,6 +62,7 @@ By applying convention rules, teams can create a more collaborative and coherent
 .. toctree::
 	:maxdepth: 1
 
+	Rule: Use `!=` Not `<>` <convention/CV01>
 	Rule: Use COALESCE Instead of IFNULL or NVL <convention/CV02>
 	Rule: Use LEFT JOIN Instead of RIGHT JOIN <convention/CV08>
 

--- a/server/src/linter/rules/aliasing/AL04.ts
+++ b/server/src/linter/rules/aliasing/AL04.ts
@@ -1,0 +1,126 @@
+
+import { ServerSettings } from "../../../settings";
+import { Diagnostic, Range } from 'vscode-languageserver/node';
+import { RuleType } from '../enums';
+import { Rule } from '../base';
+import { FileMap } from '../../parser';
+import { excludeTokensWithMatchingScopes, includeTokensWithMatchingScopes } from '../../parser/token';
+import { ObjectAST, StatementAST } from '../../parser/ast';
+
+
+export class UniqueTable extends Rule<FileMap>{
+  readonly is_fix_compatible: boolean = false;
+  readonly name: string = "unique_table";
+  readonly code: string = "AL04";
+  readonly message: string = "Table aliases should be unique within each clause.";
+  readonly relatedInformation: string = "";
+	readonly type: RuleType = RuleType.PARSER;
+  readonly ruleGroup: string = 'aliasing';
+
+  /**
+   * Creates an instance of UniqueTable.
+   * @param {ServerSettings} settings The server settings
+   * @param {number} problems The number of problems identified in the source code
+   * @memberof UniqueTable
+   */
+  constructor(settings: ServerSettings, problems: number) {
+      super(settings, problems);
+  }
+
+  /**
+   * Evaluates the given Abstract Syntax Tree (AST) to identify redundant aliases in column definitions.
+   * 
+   * @param ast - The Abstract Syntax Tree (AST) representing the SQL file structure.
+   * @param documentUri - The URI of the document being evaluated, or null if not applicable.
+   * @returns An array of Diagnostic objects representing the errors found, or null if no errors are found or the rule is disabled.
+   */
+  evaluate(ast: FileMap, documentUri: string | null = null): Diagnostic[] | null {
+
+    if (this.enabled === false) {
+      return null;
+    }
+		const errors: Diagnostic[] = [];
+    for (const i in ast) {
+      const aliases: Map<string, Range[]> = new Map();
+      const from = ast[i].from;
+      if (from) {
+        const fromTokens = excludeTokensWithMatchingScopes(
+          from.tokens,
+          [
+            'punctuation.whitespace.sql',
+            'punctuation.whitespace.leading.sql',
+            'punctuation.whitespace.trailing.sql',
+            'keyword.from.sql'
+          ]
+        );
+        const fromRange = {
+          start: {
+            line: fromTokens[0].lineNumber??0,
+            character: fromTokens[0].startIndex??0
+          },
+          end: {
+            line: fromTokens[fromTokens.length - 1].lineNumber??0,
+            character: fromTokens[fromTokens.length - 1].endIndex??0
+          }
+        };
+        if (from.alias == null && from instanceof ObjectAST) {
+          aliases.set(from.object??'', [fromRange]);
+        } else if (from.alias != null && from instanceof ObjectAST) {
+          aliases.set(from.alias??'', [fromRange]);
+        }
+      }
+
+      if (ast[i].joins) {
+        ast[i].joins.map(join => {
+          if (join.source) {
+            const sourceTokens = excludeTokensWithMatchingScopes(
+              join.source.tokens,
+              [
+                'punctuation.whitespace.sql',
+                'punctuation.whitespace.leading.sql',
+                'punctuation.whitespace.trailing.sql',
+                'keyword.join.sql'
+              ]
+            );
+            const sourceRange = {
+              start: {
+                line: sourceTokens[0].lineNumber??0,
+                character: sourceTokens[0].startIndex??0
+              },
+              end: {
+                line: sourceTokens[sourceTokens.length - 1].lineNumber??0,
+                character: sourceTokens[sourceTokens.length - 1].endIndex??0
+              }
+            };
+            if (join.source.alias == null && join.source instanceof ObjectAST) {
+              let aliasesCache = aliases.get(join.source.object??'');
+              if (!aliasesCache) {
+                aliasesCache = [];
+              }
+              aliasesCache.push(sourceRange);
+              aliases.set(join.source.object??'', aliasesCache);
+            } else if (join.source.alias != null && join.source instanceof ObjectAST) {
+              let aliasesCache = aliases.get(join.source.alias??'');
+              if (!aliasesCache) {
+                aliasesCache = [];
+              }
+              aliasesCache.push(sourceRange);
+              aliases.set(join.source.alias??'', aliasesCache);
+            }
+          }
+        });
+      }
+
+      for (const [alias, ranges] of aliases) {
+        if (ranges.length > 1) {
+          for (const range of ranges) {
+            errors.push(this.createDiagnostic(range, documentUri));
+          }
+        }
+      }
+    }
+
+    return errors.length > 0 ? errors : null;
+  }
+
+}

--- a/server/src/linter/rules/aliasing/AL05.ts
+++ b/server/src/linter/rules/aliasing/AL05.ts
@@ -1,9 +1,6 @@
 
 import { ServerSettings } from "../../../settings";
-import {
-  Diagnostic,
-  DiagnosticTag
-} from 'vscode-languageserver/node';
+import { Diagnostic } from 'vscode-languageserver/node';
 import { RuleType } from '../enums';
 import { Rule } from '../base';
 import { FileMap } from '../../parser';

--- a/server/src/linter/rules/aliasing/AL06.ts
+++ b/server/src/linter/rules/aliasing/AL06.ts
@@ -4,7 +4,6 @@ import { Diagnostic } from 'vscode-languageserver/node';
 import { RuleType } from '../enums';
 import { Rule } from '../base';
 import { FileMap } from '../../parser';
-import { StatementAST } from '../../parser/ast';
 import { excludeTokensWithMatchingScopes, includeTokensWithMatchingScopes } from '../../parser/token';
 
 

--- a/server/src/linter/rules/aliasing/AL08.ts
+++ b/server/src/linter/rules/aliasing/AL08.ts
@@ -1,10 +1,6 @@
 
 import { ServerSettings } from "../../../settings";
-import {
-  Diagnostic,
-  DiagnosticTag,
-  Range
-} from 'vscode-languageserver/node';
+import { Diagnostic, Range } from 'vscode-languageserver/node';
 import { RuleType } from '../enums';
 import { Rule } from '../base';
 import { FileMap } from '../../parser';

--- a/server/src/linter/rules/aliasing/rules.ts
+++ b/server/src/linter/rules/aliasing/rules.ts
@@ -3,13 +3,14 @@ import { Rule } from '../base';
 import { ServerSettings } from '../../../settings';
 import { Table } from './AL01';
 import { ColumnAlias } from './AL02';
+import { UniqueTable } from './AL04';
 import { UnusedAlias } from './AL05';
 import { TableAlias } from './AL06';
 import { UniqueColumn } from './AL08';
 import { RedundantColumnAlias } from './AL09';
 import { FileMap } from '../../parser';
 
-export const classes = [Table, ColumnAlias, UnusedAlias, TableAlias, UniqueColumn, RedundantColumnAlias];
+export const classes = [Table, ColumnAlias, UniqueTable, UnusedAlias, TableAlias, UniqueColumn, RedundantColumnAlias];
 
 /**
  * Generates an array of aliasing rules based on the provided settings and problems count.

--- a/server/src/linter/rules/convention/CV01.ts
+++ b/server/src/linter/rules/convention/CV01.ts
@@ -13,7 +13,7 @@ export class NotEqual extends Rule<string> {
   readonly name: string = "not_equal";
   readonly code: string = "CV01";
   readonly message: string = "Use `!=` instead of `<>.";
-	readonly relatedInformation: string = ".";
+	readonly relatedInformation: string = "For consistency and clarity, it is recommended to use `!=` instead of `<>`.";
   readonly pattern: RegExp = /<>/gmi;
   readonly severity: DiagnosticSeverity = DiagnosticSeverity.Warning;
   readonly ruleGroup: string = 'convention';

--- a/server/src/tests/linter/rules/aliasing/AL04.test.ts
+++ b/server/src/tests/linter/rules/aliasing/AL04.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @fileoverview Test suite for AL05
+ * module
+ */
+
+import { expect } from 'chai';
+import { defaultSettings } from '../../../../settings';
+import { UniqueTable } from '../../../../linter/rules/aliasing/AL04';
+import { FileMap, Parser } from '../../../../linter/parser';
+import { StatementAST } from '../../../../linter/parser/ast';
+
+describe('UniqueTable', () => {
+    let instance: UniqueTable;
+
+    beforeEach(() => {
+        instance = new UniqueTable(defaultSettings, 0);
+    });
+
+    it('should return null when rule is disabled', () => {
+        instance.enabled = false;
+        const result = instance.evaluate({1: new StatementAST()} as FileMap);
+        expect(result).to.be.null;
+    });
+
+    it('should return diagnostic when rule is enabled and as used', async () => {
+        instance.enabled = true;
+
+
+        const parser = new Parser();
+
+        const result = instance.evaluate(await parser.parse({text:'SELECT t.col1 as c\n FROM dataset.table t\n inner join dataset.table_other t\n;\n', uri: 'test.sql', languageId: 'sql', version: 0}));
+        expect(result).to.deep.equal([{
+                code: instance.diagnosticCode,
+                codeDescription: {href: instance.diagnosticCodeDescription},
+                message: instance.message,
+                severity: instance.severity,
+                range: {
+                    start: { line: 1, character: 6 },
+                    end: { line: 1, character: 21 }
+                },
+                source: instance.source,
+            },
+            {
+                code: instance.diagnosticCode,
+                codeDescription: {href: instance.diagnosticCodeDescription},
+                message: instance.message,
+                severity: instance.severity,
+                range: {
+                    start: { line: 2, character: 12 },
+                    end: { line: 2, character: 33 }
+                },
+                source: instance.source,
+            }
+        ]);
+    });
+
+    it('should return null when rule is enabled but pattern does not match', async () => {
+        instance.enabled = true;
+
+        const parser = new Parser();
+
+        const result = instance.evaluate(await parser.parse({text:'SELECT t.col1 c\n FROM dataset.table t', uri: 'test.sql', languageId: 'sql', version: 0}));
+        expect(result).to.be.null;
+    });
+});


### PR DESCRIPTION
The rule enforces the use of unique table aliases within each clause to enhance clarity and prevent ambiguity in SQL queries.

<!-- readthedocs-preview bigquerysqlformatter start -->
----
📚 Documentation preview 📚: https://bigquerysqlformatter--200.org.readthedocs.build/en/200/

<!-- readthedocs-preview bigquerysqlformatter end -->