### PR TITLE
Improve token handling in CaseStatementWhenAST

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "icon": "images/BigQuerySQLFormatter_transparent_128.png",
   "author": "sean-conkie",
   "license": "MIT",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/sean-conkie/BigQuerySQLFormatter-extension.git"

--- a/server/src/linter/parser/ast.ts
+++ b/server/src/linter/parser/ast.ts
@@ -410,7 +410,16 @@ export class CaseStatementWhenAST extends AST {
    */
   constructor(when: MatchedRule, then: MatchedRule) {
 
-    const tokens = [...when.tokens, ...then.tokens];
+    const tokens = [];
+    
+    if (when.tokens.length > 0) {
+      tokens.push(...when.tokens);
+    }
+    
+    if (then.tokens.length > 0) {
+      tokens.push(...then.tokens);
+    }
+
     super(tokens);
 
     this.when = new ComparisonGroupAST(when.matches ?? []);


### PR DESCRIPTION
This pull request updates the version to 0.1.1 and enhances the token handling in the `CaseStatementWhenAST` class. The constructor now conditionally adds tokens from the `when` and `then` parameters only if they are present, improving the robustness of the token management. This change ensures that unnecessary empty tokens are not included, leading to cleaner and more efficient code.