### PR TITLE
Add SpacesNotTabs rule to enforce spaces for indentation

### DIFF
--- a/docs/source/rules/convention/CV12.rst
+++ b/docs/source/rules/convention/CV12.rst
@@ -1,0 +1,56 @@
+==========================================
+Rule: Use Spaces for Indentation, Not Tabs
+==========================================
+
+**Rule Code:** ``CV12``
+
+**Name:** ``spaces_not_tabs``
+
+Overview
+--------
+
+In SQL and programming in general, it is a best practice to use spaces for indentation instead of tabs. While both spaces and tabs can be used to indent code, spaces provide more consistent formatting across different environments, editors, and systems. Using spaces for indentation ensures that the code appears the same regardless of the viewer’s settings and avoids issues with misaligned or uneven code that can result from the use of tabs.
+
+Explanation
+-----------
+
+Anti-pattern: Using Tabs for Indentation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Using tabs for indentation can lead to inconsistent formatting because different editors and environments interpret tabs differently. A tab might be displayed as two, four, or even eight spaces depending on the configuration of the user's editor, making it difficult to maintain a consistent look and feel for the code. This can lead to confusion, especially when multiple developers work on the same codebase.
+
+**Example of Using Tabs for Indentation (Anti-pattern):**
+
+.. code-block:: sql
+
+    SELECT *
+    FROM    orders
+        JOIN customers ON orders.customer_id = customers.id;
+
+In this example, tabs are used for indentation, which can result in inconsistent alignment depending on the viewer's editor settings.
+
+Best Practice: Use Spaces for Indentation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To ensure consistent formatting and readability across different environments, spaces should be used for indentation. Most coding standards recommend using spaces because they provide a uniform way of displaying indents, regardless of the editor settings.
+
+**Refactored Example Using Spaces for Indentation (Best Practice):**
+
+.. code-block:: sql
+
+    SELECT *
+    FROM    orders
+    JOIN    customers ON orders.customer_id = customers.id;
+
+In this refactored example, spaces are used for indentation, ensuring that the code appears consistent across different editors and systems.
+
+Conclusion
+----------
+
+Using spaces for indentation instead of tabs ensures that SQL queries are consistently formatted, readable, and maintainable. This practice reduces the likelihood of formatting issues caused by different tab width settings in various editors and environments, leading to cleaner and more professional code.
+
+Groups:
+-------
+
+- ``all``
+- ``convention``

--- a/docs/source/rules/index.rst
+++ b/docs/source/rules/index.rst
@@ -65,6 +65,7 @@ By applying convention rules, teams can create a more collaborative and coherent
 	Rule: Use `!=` Not `<>` <convention/CV01>
 	Rule: Use COALESCE Instead of IFNULL or NVL <convention/CV02>
 	Rule: Use LEFT JOIN Instead of RIGHT JOIN <convention/CV08>
+	Rule: Use Spaces for Indentation, Not Tabs <convention/CV12>
 
 .. _layout-rules:
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "publisher": "sean-conkie",
   "categories": [
     "Programming Languages",
-    "Linters"
+    "Linters",
+    "Formatters"
   ],
   "keywords": [
     "multi-root ready",
@@ -77,7 +78,13 @@
         "scopeName": "source.googlesql",
         "path": "./server/src/linter/syntaxes/googlesql.tmLanguage.json"
       }
-    ]
+    ],
+    "configurationDefaults": {
+      "[googlesql]": {
+        "editor.tabSize": 2,
+        "editor.insertSpaces": true
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/server/src/linter/rules/convention/CV12.ts
+++ b/server/src/linter/rules/convention/CV12.ts
@@ -1,0 +1,84 @@
+import { ServerSettings } from "../../../settings";
+import { CodeAction, CodeActionKind, Diagnostic, DiagnosticSeverity, TextDocumentIdentifier, TextEdit } from 'vscode-languageserver/node';
+import { Rule } from '../base';
+
+
+/**
+ * The SpacesNotTabs rule
+ * @class SpacesNotTabs
+ * @extends Rule
+ * @memberof Linter.Rules
+ */
+export class SpacesNotTabs extends Rule<string> {
+  readonly name: string = "spaces_not_tabs";
+  readonly code: string = "CV12";
+  readonly message: string = "Use spaces for indentation instead of tabs.";
+	readonly relatedInformation: string = "To ensure consistent formatting and readability across different environments, spaces should be used for indentation.";
+  readonly pattern: RegExp = /\t+/gmi;
+  readonly severity: DiagnosticSeverity = DiagnosticSeverity.Warning;
+  readonly ruleGroup: string = 'convention';
+  readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
+  readonly codeActionTitle = 'Replace with spaces';
+
+  /**
+   * Creates an instance of SpacesNotTabs.
+   * @param {ServerSettings} settings The server settings
+   * @param {number} problems The number of problems identified in the source code
+   * @memberof SpacesNotTabs
+   */
+  constructor(settings: ServerSettings, problems: number) {
+    super(settings, problems);
+  }
+
+  /**
+   * Evaluates the given test string against a pattern and returns diagnostics if the pattern matches.
+   *
+   * @param test - The string to be tested against the pattern.
+   * @param documentUri - The URI of the document being evaluated, optional.
+   * @returns An array of diagnostics if the pattern matches, otherwise null.
+   */
+  evaluate(test: string, documentUri: string | null = null): Diagnostic[] | null {
+
+    if (this.enabled === false) {
+      return null;
+    }
+
+    if (this.pattern.test(test)) {
+      return this.evaluateMultiRegexTest(test, documentUri);
+    }
+
+    return null;
+
+  }
+  
+  /**
+   * Creates a set of code actions to fix diagnostics.
+   *
+   * @param textDocument - The identifier of the text document where the diagnostic was reported.
+   * @param diagnostic - The diagnostic information about the issue to be fixed.
+   * @returns An array of code actions that can be applied to fix the issue.
+   */
+  createCodeAction(textDocument: TextDocumentIdentifier, diagnostic: Diagnostic): CodeAction[] {
+    const count = diagnostic.range.end.character - diagnostic.range.start.character;
+    const edit = {
+        changes: {
+            [textDocument.uri]: [
+                TextEdit.replace(diagnostic.range, ' '.repeat(count * 2))
+            ]
+        }
+    };
+    const actions: CodeAction[] = [];
+    
+    this.codeActionKind.map((kind) => {
+      const fix = CodeAction.create(
+        this.codeActionTitle,
+        edit,
+        kind
+      );
+      fix.diagnostics = [diagnostic];
+      actions.push(fix);
+    });
+
+    return actions;
+  }
+}

--- a/server/src/linter/rules/convention/rules.ts
+++ b/server/src/linter/rules/convention/rules.ts
@@ -11,11 +11,14 @@ import { ServerSettings } from '../../../settings';
 import { NotEqual } from './CV01';
 import { Coalesce } from './CV02';
 import { LeftJoin } from './CV08';
+import { SpacesNotTabs } from './CV12';
 import { FileMap } from '../../parser';
 
 export const classes = [NotEqual,
 												Coalesce,
-												LeftJoin];
+												LeftJoin,
+												SpacesNotTabs
+											];
 
 export function conventionRules(settings: ServerSettings, problems: number): Rule<string | FileMap>[] {
 

--- a/server/src/linter/syntaxes/googlesql.tmLanguage.json
+++ b/server/src/linter/syntaxes/googlesql.tmLanguage.json
@@ -59,15 +59,15 @@
     "whitespace": {
       "patterns": [
         {
-          "match": "^ *",
+          "match": "^(?: |\\t)*",
           "name": "punctuation.whitespace.leading.sql"
         },
         {
-          "match": " *$",
+          "match": "(?: |\\t)*$",
           "name": "punctuation.whitespace.trailing.sql"
         },
         {
-          "match": " *",
+          "match": "(?: |\\t)*",
           "name": "punctuation.whitespace.sql"
         }
       ]

--- a/server/src/tests/linter/rules/convention/CV12.test.ts
+++ b/server/src/tests/linter/rules/convention/CV12.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @fileoverview Test suite for LT13 module
+ */
+
+import { expect } from 'chai';
+import { defaultSettings } from '../../../../settings';
+import { SpacesNotTabs } from '../../../../linter/rules/convention/CV12';
+import { Parser } from '../../../../linter/parser';
+
+describe('SpacesNotTabs', () => {
+    let instance: SpacesNotTabs;
+
+    beforeEach(() => {
+        instance = new SpacesNotTabs(defaultSettings, 0);
+    });
+
+    it('should return null when rule is disabled', () => {
+        instance.enabled = false;
+        const result = instance.evaluate('test');
+        expect(result).to.be.null;
+    });
+
+    it('should return diagnostic when rule is enabled and pattern matches', () => {
+        instance.enabled = true;
+        const result = instance.evaluate('select a.col,\tb.col from dataset.table a left join dataset.table b on a.col != b.col');
+        expect(result).to.deep.equal([{
+            code: instance.diagnosticCode,
+            codeDescription: {href: instance.diagnosticCodeDescription},
+            message: instance.message,
+            severity: instance.severity,
+            range: {
+                start: { line: 0, character: 13 },
+                end: { line: 0, character: 14 }
+            },
+            source: instance.source
+        }]);
+    });
+
+    it('should return codeaction when rule is enabled and as used', async () => {
+        instance.enabled = true;
+        const parser = new Parser();
+        await parser.parse({text:'select a.col,\tb.col from dataset.table a left join dataset.table b on a.col != b.col', uri: 'test.sql', languageId: 'sql', version: 0});
+        const diagnostics = instance.evaluate('select a.col,\tb.col from dataset.table a left join dataset.table b on a.col != b.col');
+        const actions = instance.createCodeAction({uri: 'test.sql'}, diagnostics![0]);
+        expect(actions).to.deep.equal(instance.codeActionKind.map(kind => {
+            return {
+                title: instance.codeActionTitle, edit:{
+                changes: {
+                        ['test.sql']: [
+                            {
+                                newText: '  ',
+                                range: {
+                                    start: { line: 0, character: 13 },
+                                    end: { line: 0, character: 14 }
+                                }
+                            }
+                        ]
+                    }
+                },
+                kind: kind,
+                diagnostics: diagnostics
+            };
+        }));
+    });
+
+    it('should return null when rule is enabled but pattern does not match', () => {
+        instance.enabled = true;
+        const result = instance.evaluate('select a.col, b.col from dataset.table a left join dataset.table b on a.col != b.col');
+        expect(result).to.be.null;
+    });
+});


### PR DESCRIPTION
This pull request introduces a new rule, `SpacesNotTabs`, which enforces the use of spaces for indentation instead of tabs. This rule aims to ensure consistent formatting and readability across different environments, addressing potential issues caused by varying tab width settings in editors. The implementation includes diagnostics for identifying tab usage and provides code actions to replace tabs with spaces. Additionally, the rule has been integrated into the existing convention rules and is accompanied by a comprehensive test suite to validate its functionality.

<!-- readthedocs-preview bigquerysqlformatter start -->
----
📚 Documentation preview 📚: https://bigquerysqlformatter--202.org.readthedocs.build/en/202/

<!-- readthedocs-preview bigquerysqlformatter end -->