### PR TITLE
Add IsNull rule for NULL comparisons

### DIFF
--- a/docs/source/rules/convention/CV04.rst
+++ b/docs/source/rules/convention/CV04.rst
@@ -4,7 +4,7 @@ Rule: Use `COUNT(1)` to Express “Count Number of Rows”
 
 **Rule Code:** ``CV04``
 
-**Name:** ``count``
+**Name:** ``count_rows``
 
 Overview
 --------

--- a/docs/source/rules/convention/CV05.rst
+++ b/docs/source/rules/convention/CV05.rst
@@ -1,0 +1,66 @@
+=========================================================
+Rule: Comparisons with `NULL` Should Use `IS` or `IS NOT`
+=========================================================
+
+**Rule Code:** ``CV05``
+
+**Name:** ``is_null``
+
+Overview
+--------
+
+In SQL, comparisons with `NULL` values must be made using the `IS` or `IS NOT` operators. This is because `NULL` in SQL represents an unknown or missing value, and comparisons using standard operators like `=` or `!=` will not work as expected. Using `IS NULL` and `IS NOT NULL` provides a clear and explicit way to handle `NULL` values in conditions, avoiding potential logical errors and improving the readability of queries.
+
+Explanation
+-----------
+
+Anti-pattern: Using `=` or `!=` for `NULL` Comparisons
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Using `=` or `!=` to compare a column with `NULL` is an anti-pattern because these operators do not behave as expected with `NULL` values. Since `NULL` represents an unknown value, comparisons using `=` or `!=` will always return `false`, which can lead to incorrect query results.
+
+**Example of Incorrect `NULL` Comparison (Anti-pattern):**
+
+.. code-block:: sql
+
+    SELECT *
+    FROM orders
+    WHERE order_status = NULL;
+
+In this example, the query is incorrectly attempting to compare `order_status` with `NULL` using the `=` operator, which will not return the expected results because `NULL` cannot be compared using standard equality operators.
+
+Best Practice: Use `IS NULL` or `IS NOT NULL` for `NULL` Comparisons
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To correctly check for `NULL` values, use the `IS NULL` or `IS NOT NULL` operators. These operators explicitly check for the presence or absence of `NULL` values in a column, ensuring that the query works as intended.
+
+**Refactored Example Using `IS NULL` (Best Practice):**
+
+.. code-block:: sql
+
+    SELECT *
+    FROM orders
+    WHERE order_status IS NULL;
+
+In this refactored example, the query correctly checks whether `order_status` is `NULL` using the `IS NULL` operator. This ensures that the query behaves as expected.
+
+**Refactored Example Using `IS NOT NULL` (Best Practice):**
+
+.. code-block:: sql
+
+    SELECT *
+    FROM orders
+    WHERE order_status IS NOT NULL;
+
+This example demonstrates how to check for non-`NULL` values using the `IS NOT NULL` operator, which is the correct approach when filtering out `NULL` values.
+
+Conclusion
+----------
+
+Comparisons with `NULL` should always use `IS` or `IS NOT` to ensure correct behavior and avoid logical errors. Following this rule helps improve the clarity and accuracy of SQL queries that involve `NULL` values.
+
+Groups:
+-------
+
+- `all <../..>`_
+- `convention <../..#convention-rules>`_

--- a/docs/source/rules/index.rst
+++ b/docs/source/rules/index.rst
@@ -65,6 +65,7 @@ By applying convention rules, teams can create a more collaborative and coherent
 	Rule: Use `!=` Not `<>` <convention/CV01>
 	Rule: Use COALESCE Instead of IFNULL or NVL <convention/CV02>
 	Rule: Use `COUNT(1)` to Express “Count Number of Rows” <convention/CV04>
+	Rule: Comparisons with `NULL` Should Use `IS` or `IS NOT` <convention/CV05>
 	Rule: Use LEFT JOIN Instead of RIGHT JOIN <convention/CV08>
 	Rule: Use Spaces for Indentation, Not Tabs <convention/CV12>
 

--- a/server/src/linter/rules/convention/CV04.ts
+++ b/server/src/linter/rules/convention/CV04.ts
@@ -10,7 +10,7 @@ import { Rule } from '../base';
  * @memberof Linter.Rules
  */
 export class Count extends Rule<string> {
-  readonly name: string = "count";
+  readonly name: string = "count_rows";
   readonly code: string = "CV04";
   readonly message: string = "Use COUNT(1) to express “count number of rows”.";
 	readonly relatedInformation: string = "";

--- a/server/src/linter/rules/convention/CV05.ts
+++ b/server/src/linter/rules/convention/CV05.ts
@@ -4,27 +4,27 @@ import { Rule } from '../base';
 
 
 /**
- * The Count rule
- * @class Count
+ * The IsNull rule
+ * @class IsNull
  * @extends Rule
  * @memberof Linter.Rules
  */
-export class Count extends Rule<string> {
-  readonly name: string = "count_rows";
-  readonly code: string = "CV04";
-  readonly message: string = "Use COUNT(1) to express “count number of rows”.";
-	readonly relatedInformation: string = "For clarity and to follow best practices, it is recommended to use `COUNT(1)` when counting rows.";
-  readonly pattern: RegExp = /count\s*?\(\s*?(?:distinct\s*?)?(\*)\s*?\)/gmi;
+export class IsNull extends Rule<string> {
+  readonly name: string = "is_null";
+  readonly code: string = "CV05";
+  readonly message: string = "Comparisons with NULL should use “IS” or “IS NOT”.";
+	readonly relatedInformation: string = "Using `=` or `!=` to compare a column with `NULL` is an anti-pattern because these operators do not behave as expected with `NULL` values.";
+  readonly pattern: RegExp = /(!?=)\s*?null/gmi;
   readonly severity: DiagnosticSeverity = DiagnosticSeverity.Warning;
   readonly ruleGroup: string = 'convention';
   readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
-  readonly codeActionTitle = 'Replace with `1`';
+  readonly codeActionTitle = 'Replace with ';
 
   /**
-   * Creates an instance of Count.
+   * Creates an instance of IsNull.
    * @param {ServerSettings} settings The server settings
    * @param {number} problems The number of problems identified in the source code
-   * @memberof Count
+   * @memberof IsNull
    */
   constructor(settings: ServerSettings, problems: number) {
     super(settings, problems);
@@ -59,10 +59,11 @@ export class Count extends Rule<string> {
    * @returns An array of code actions that can be applied to fix the issue.
    */
   createCodeAction(textDocument: TextDocumentIdentifier, diagnostic: Diagnostic): CodeAction[] {
+    const text = diagnostic.range.end.character - diagnostic.range.start.character === 1? 'is' : 'is null';
     const edit = {
         changes: {
             [textDocument.uri]: [
-                TextEdit.replace(diagnostic.range, '1')
+                TextEdit.replace(diagnostic.range, text)
             ]
         }
     };
@@ -70,7 +71,7 @@ export class Count extends Rule<string> {
     
     this.codeActionKind.map((kind) => {
       const fix = CodeAction.create(
-        this.codeActionTitle,
+        `${this.codeActionTitle}${text}`,
         edit,
         kind
       );

--- a/server/src/linter/rules/convention/rules.ts
+++ b/server/src/linter/rules/convention/rules.ts
@@ -11,6 +11,7 @@ import { ServerSettings } from '../../../settings';
 import { NotEqual } from './CV01';
 import { Coalesce } from './CV02';
 import { Count } from './CV04';
+import { IsNull } from './CV05';
 import { LeftJoin } from './CV08';
 import { SpacesNotTabs } from './CV12';
 import { FileMap } from '../../parser';
@@ -18,6 +19,7 @@ import { FileMap } from '../../parser';
 export const classes = [NotEqual,
 												Coalesce,
 												Count,
+												IsNull,
 												LeftJoin,
 												SpacesNotTabs
 											];

--- a/server/src/tests/linter/rules/convention/CV05.test.ts
+++ b/server/src/tests/linter/rules/convention/CV05.test.ts
@@ -63,6 +63,49 @@ describe('IsNull', () => {
         }));
     });
 
+    it('should return diagnostic when rule is enabled and pattern matches', () => {
+        instance.enabled = true;
+        const result = instance.evaluate('select a.col != null from dataset.table a left join dataset.table b on a.col = b.col');
+        expect(result).to.deep.equal([{
+            code: instance.diagnosticCode,
+            codeDescription: {href: instance.diagnosticCodeDescription},
+            message: instance.message,
+            severity: instance.severity,
+            range: {
+                start: { line: 0, character: 13 },
+                end: { line: 0, character: 15 }
+            },
+            source: instance.source
+        }]);
+    });
+
+    it('should return codeaction when rule is enabled and as used', async () => {
+        instance.enabled = true;
+        const parser = new Parser();
+        await parser.parse({text:'select a.col != null from dataset.table a left join dataset.table b on a.col = b.col', uri: 'test.sql', languageId: 'sql', version: 0});
+        const diagnostics = instance.evaluate('select a.col != null from dataset.table a left join dataset.table b on a.col = b.col');
+        const actions = instance.createCodeAction({uri: 'test.sql'}, diagnostics![0]);
+        expect(actions).to.deep.equal(instance.codeActionKind.map(kind => {
+            return {
+                title: 'Replace with is null', edit:{
+                changes: {
+                        ['test.sql']: [
+                            {
+                                newText: 'is null',
+                                range: {
+                                    start: { line: 0, character: 13 },
+                                    end: { line: 0, character: 15 }
+                                }
+                            }
+                        ]
+                    }
+                },
+                kind: kind,
+                diagnostics: diagnostics
+            };
+        }));
+    });
+
     it('should return null when rule is enabled but pattern does not match', () => {
         instance.enabled = true;
         const result = instance.evaluate('select a.col is null from dataset.table a left join dataset.table b on a.col = b.col');

--- a/server/src/tests/linter/rules/convention/CV05.test.ts
+++ b/server/src/tests/linter/rules/convention/CV05.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @fileoverview Test suite for LT13 module
+ */
+
+import { expect } from 'chai';
+import { defaultSettings } from '../../../../settings';
+import { IsNull } from '../../../../linter/rules/convention/CV05';
+import { Parser } from '../../../../linter/parser';
+
+describe('IsNull', () => {
+    let instance: IsNull;
+
+    beforeEach(() => {
+        instance = new IsNull(defaultSettings, 0);
+    });
+
+    it('should return null when rule is disabled', () => {
+        instance.enabled = false;
+        const result = instance.evaluate('test');
+        expect(result).to.be.null;
+    });
+
+    it('should return diagnostic when rule is enabled and pattern matches', () => {
+        instance.enabled = true;
+        const result = instance.evaluate('select a.col = null from dataset.table a left join dataset.table b on a.col = b.col');
+        expect(result).to.deep.equal([{
+            code: instance.diagnosticCode,
+            codeDescription: {href: instance.diagnosticCodeDescription},
+            message: instance.message,
+            severity: instance.severity,
+            range: {
+                start: { line: 0, character: 13 },
+                end: { line: 0, character: 14 }
+            },
+            source: instance.source
+        }]);
+    });
+
+    it('should return codeaction when rule is enabled and as used', async () => {
+        instance.enabled = true;
+        const parser = new Parser();
+        await parser.parse({text:'select a.col = null from dataset.table a left join dataset.table b on a.col = b.col', uri: 'test.sql', languageId: 'sql', version: 0});
+        const diagnostics = instance.evaluate('select a.col = null from dataset.table a left join dataset.table b on a.col = b.col');
+        const actions = instance.createCodeAction({uri: 'test.sql'}, diagnostics![0]);
+        expect(actions).to.deep.equal(instance.codeActionKind.map(kind => {
+            return {
+                title: 'Replace with is', edit:{
+                changes: {
+                        ['test.sql']: [
+                            {
+                                newText: 'is',
+                                range: {
+                                    start: { line: 0, character: 13 },
+                                    end: { line: 0, character: 14 }
+                                }
+                            }
+                        ]
+                    }
+                },
+                kind: kind,
+                diagnostics: diagnostics
+            };
+        }));
+    });
+
+    it('should return null when rule is enabled but pattern does not match', () => {
+        instance.enabled = true;
+        const result = instance.evaluate('select a.col is null from dataset.table a left join dataset.table b on a.col = b.col');
+        expect(result).to.be.null;
+    });
+});


### PR DESCRIPTION
This pull request renames the existing rule from 'count' to 'count_rows' for improved clarity. Additionally, it introduces a new rule, 'IsNull', which enforces the proper use of `IS` and `IS NOT` for NULL comparisons in SQL. This change aims to enhance code quality by preventing common logical errors associated with NULL value comparisons.

<!-- readthedocs-preview bigquerysqlformatter start -->
----
📚 Documentation preview 📚: https://bigquerysqlformatter--207.org.readthedocs.build/en/207/

<!-- readthedocs-preview bigquerysqlformatter end -->