### PR TITLE
Fix null check in UnusedAlias rule

### DIFF
--- a/server/src/linter/rules/aliasing/AL05.ts
+++ b/server/src/linter/rules/aliasing/AL05.ts
@@ -96,7 +96,7 @@ export class UnusedAlias extends Rule<FileMap>{
     const errors: Diagnostic[] = [];
 
     if (column instanceof ColumnAST) {
-      if (column.source == null) {
+      if (column.source == null && column.column != null) {
         const columnToken = column.tokens.find(token => token.scopes.includes("meta.column.sql"));
         if (columnToken) {
           errors.push(this.createDiagnostic({start: {line: columnToken.lineNumber ?? 0, character: columnToken.startIndex ?? 0}, end: {line: columnToken.lineNumber ?? 0, character: columnToken.endIndex ?? 0}}, documentUri));


### PR DESCRIPTION
This pull request fixes a null check issue in the `UnusedAlias` rule. Previously, the check was not considering the case when the `source` is null but the `column` is not null. This caused errors to be pushed to the `errors` array incorrectly. The fix ensures that the check includes both conditions correctly.