### PR TITLE
Update OrderAST constructor and fix missing use cases for UnusedAlias rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,4 +24,4 @@ version:
 	@npm version $(VERSION)
 	@cd ./server && npm version $(VERSION) && cd ..
 	@cd ./client && npm version $(VERSION)
-	echo "Version $(VERSION) set"
+	@echo "Version $(VERSION) set"

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bigquerysqlformatter-client",
-  "version": "0.0.6",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bigquerysqlformatter-client",
-      "version": "0.0.6",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@types/glob": "^8.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "description": "VSCode part of a language server",
   "author": "sean-conkie",
   "license": "MIT",
-  "version": "0.0.6",
+  "version": "0.2.1",
   "publisher": "vscode",
   "repository": {
     "type": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bigquerysqlformatter",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bigquerysqlformatter",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "icon": "images/BigQuerySQLFormatter_transparent_128.png",
   "author": "sean-conkie",
   "license": "MIT",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/sean-conkie/BigQuerySQLFormatter-extension.git"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bigquerysqlformatter-language-server",
-  "version": "0.0.6",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bigquerysqlformatter-language-server",
-      "version": "0.0.6",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "onigasm": "^2.2.5",

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bigquerysqlformatter-language-server",
   "description": "Language server.",
-  "version": "0.0.6",
+  "version": "0.2.1",
   "author": "sean-conkie",
   "license": "MIT",
   "engines": {

--- a/server/src/linter/parser/ast.ts
+++ b/server/src/linter/parser/ast.ts
@@ -258,6 +258,23 @@ export class KeywordAST extends ASTWithValue<string> {
 export class OrderAST extends AST {
   column: Column | null = null;
   direction: string | null = null;
+
+  constructor(matchedRule: MatchedRule) {
+    super(matchedRule.tokens);
+
+    const column = createColumn(matchedRule);
+    const directionMatch = matchedRule.matches?.find((match) => match.rule?.type === 'direction') ?? null;
+
+    this.column = column;
+    this.tokens.push(...column.tokens);
+
+    if (directionMatch) {
+      this.direction = findToken(directionMatch.tokens, "keyword.order.direction.sql")?.value ?? null;
+      this.tokens.push(...directionMatch.tokens);
+    }
+
+  }
+
 }
 
 /**
@@ -292,7 +309,7 @@ export class WindowAST extends AST {
     const orderMatches = match.matches?.slice((orderByIndex ?? 0) + 1);
 
     this.partition = partitionMatches?.map((match) => createColumn(match) ?? null).filter((column) => column != null) as Column[];
-    this.order = orderMatches?.map((match) => new OrderAST()) ?? [];
+    this.order = orderMatches?.map((match) => new OrderAST(match)) ?? [];
   }
 }
 

--- a/server/src/linter/parser/index.ts
+++ b/server/src/linter/parser/index.ts
@@ -653,16 +653,12 @@ export class Parser {
 			if (matchedRule.rule && matchedRule.rule.recursive) {
 				const [matchedRules, y] = this.recursiveLookahead(tokens.slice(i + 1), null, matchedRule.rule.end);
 				matchedRule.matches!.push(...matchedRules);
-				matches.push(matchedRule);
 				i += y;
-				loopCounter = i;
-				reset();
-				if (exitOnMatch) {
-					break;
-				}
-				continue;
-			} else if (matchedRule.rule) {
+			}
+
+			if (matchedRule.rule) {
 				matches.push(matchedRule);
+				loopCounter = i;
 				reset();
 				if (exitOnMatch) {
 					break;

--- a/server/src/linter/syntaxes/googlesql.tmLanguage.json
+++ b/server/src/linter/syntaxes/googlesql.tmLanguage.json
@@ -649,7 +649,7 @@
       "patterns": [
         {
           "captures": {
-            "1": { "name": "keyword.order.sql" }
+            "1": { "name": "keyword.order.direction.sql" }
           },
           "match": "(?i)\\b(desc|asc)\\b",
           "name": "meta.order.sql"

--- a/server/src/linter/syntaxes/syntax.json
+++ b/server/src/linter/syntaxes/syntax.json
@@ -222,7 +222,7 @@
       "lookahead": 1,
       "negativeLookahead": ["keyword.as.sql", "entity.name.tag"],
       "recursive": false,
-      "children": null,
+      "children": ["keyword.order.direction"],
       "end": null,
       "alias": false
     },
@@ -268,7 +268,7 @@
         "entity.name.tag"
       ],
       "recursive": false,
-      "children": null,
+      "children": ["keyword.order.direction"],
       "end": null,
       "alias": false
     },
@@ -459,7 +459,7 @@
       "lookahead": 2,
       "negativeLookahead": ["keyword.as.sql", "entity.name.tag"],
       "recursive": false,
-      "children": null,
+      "children": ["keyword.order.direction"],
       "end": null,
       "alias": false
     },
@@ -470,7 +470,7 @@
       "lookahead": 1,
       "negativeLookahead": ["keyword.as.sql", "entity.name.tag"],
       "recursive": false,
-      "children": null,
+      "children": ["keyword.order.direction"],
       "end": null,
       "alias": false
     },
@@ -824,6 +824,17 @@
       "name": "keyword.order",
       "scopes": ["keyword.order.sql"],
       "type": "keyword",
+      "lookahead": 0,
+      "negativeLookahead": null,
+      "recursive": false,
+      "children": null,
+      "end": null,
+      "alias": false
+    },
+    {
+      "name": "keyword.order.direction",
+      "scopes": ["keyword.order.direction.sql"],
+      "type": "direction",
       "lookahead": 0,
       "negativeLookahead": null,
       "recursive": false,

--- a/server/src/tests/linter/rules/aliasing/AL05.test.ts
+++ b/server/src/tests/linter/rules/aliasing/AL05.test.ts
@@ -62,6 +62,66 @@ describe('UnusedAlias', () => {
         }]);
     });
 
+    it('should return diagnostic when rule is enabled and as used - case', async () => {
+        instance.enabled = true;
+
+
+        const parser = new Parser();
+
+        const result = instance.evaluate(await parser.parse({text:'SELECT t.col1 as c\n       case when 1 = 1 then col2 end col2\n FROM dataset.table t;\n', uri: 'test.sql', languageId: 'sql', version: 0}));
+        expect(result).to.deep.equal([{
+            code: instance.diagnosticCode,
+            codeDescription: {href: instance.diagnosticCodeDescription},
+            message: instance.message,
+            severity: instance.severity,
+            range: {
+                start: { line: 1, character: 28 },
+                end: { line: 1, character: 32 }
+            },
+            source: instance.source,
+        }]);
+    });
+
+    it('should return diagnostic when rule is enabled and as used - over', async () => {
+        instance.enabled = true;
+
+
+        const parser = new Parser();
+
+        const result = instance.evaluate(await parser.parse({text:'SELECT t.col1 as c\n       lead(id,1) over (partition by col order by col2) col2\n FROM dataset.table t;\n', uri: 'test.sql', languageId: 'sql', version: 0}));
+        expect(result).to.deep.equal([{
+            code: instance.diagnosticCode,
+            codeDescription: {href: instance.diagnosticCodeDescription},
+            message: instance.message,
+            severity: instance.severity,
+            range: {
+                start: { line: 1, character: 12 },
+                end: { line: 1, character: 14 }
+            },
+            source: instance.source,
+        },{
+            code: instance.diagnosticCode,
+            codeDescription: {href: instance.diagnosticCodeDescription},
+            message: instance.message,
+            severity: instance.severity,
+            range: {
+                start: { line: 1, character: 37 },
+                end: { line: 1, character: 40 }
+            },
+            source: instance.source,
+        },{
+            code: instance.diagnosticCode,
+            codeDescription: {href: instance.diagnosticCodeDescription},
+            message: instance.message,
+            severity: instance.severity,
+            range: {
+                start: { line: 1, character: 50 },
+                end: { line: 1, character: 54 }
+            },
+            source: instance.source,
+        }]);
+    });
+
     it('should return diagnostic when rule is enabled and as used - join', async () => {
         instance.enabled = true;
 


### PR DESCRIPTION
This pull request introduces a constructor for the `OrderAST` class to facilitate the parsing of columns and their directions. Additionally, the parser logic has been refactored for improved readability and streamlined rule matching. The `UnusedAlias` rule has been enhanced to support `OrderAST` and `CaseStatementAST` in its column processing, ensuring better handling of these structures during analysis. Overall, these changes aim to improve the robustness and clarity of the parsing logic.