### PR TITLE
Add LT02 rule for consistent statement indentation in SQL queries

### DIFF
--- a/docs/source/rules/index.rst
+++ b/docs/source/rules/index.rst
@@ -81,6 +81,7 @@ Layout rules are guidelines that help developers maintain a consistent and reada
 	:maxdepth: 1
 
 	Rule: Delete Trailing Whitespace <layout/LT01>
+	Rule: Columns Should Be Indented Consistently <layout/LT02>
 	Rule: Place Commas at the End of the Line <layout/LT04>
 	Rule: Function Names Must Be Immediately Followed by Parentheses <layout/LT06>
 	Rule: Select Targets Should Be on Separate Lines <layout/LT09>

--- a/docs/source/rules/layout/LT02.rst
+++ b/docs/source/rules/layout/LT02.rst
@@ -1,55 +1,57 @@
-=============================================
-Rule: Columns Should Be Indented Consistently
-=============================================
+================================================
+Rule: Statements Should Be Indented Consistently
+================================================
 
 **Rule Code:** ``LT02``
 
-**Name:** ``indent_select``
+**Name:** ``indent``
 
 Overview
 --------
 
-In SQL queries, consistent indentation of columns improves readability, maintainability, and clarity, especially in longer queries. Proper indentation makes it easier to visually distinguish between different components of the query, such as columns in the `SELECT` clause, and improves the overall organization of the code. Consistently formatting SQL queries also ensures that queries are easier to understand and maintain in collaborative environments.
+In SQL queries, consistent indentation of statements is essential for improving readability, maintainability, and clarity. Proper indentation allows developers to quickly understand the structure of a query, making it easier to spot errors, follow logic, and maintain the code over time. Consistently indented SQL queries also promote better collaboration within teams by ensuring that code is structured in a predictable and clean manner.
 
 Explanation
 -----------
 
-Anti-pattern: Inconsistent Column Indentation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Inconsistent indentation of columns in the `SELECT` clause makes queries difficult to read and can lead to confusion, especially when the query grows in complexity. Misaligned columns can make it hard to quickly scan the query and understand the data being selected, which can result in errors during maintenance or debugging.
-
-**Example of Inconsistent Column Indentation (Anti-pattern):**
-
-.. code-block:: sql
-
-    SELECT t.col1,
-    t.col2,
-       t.col3
-    FROM dataset.table t;
-
-In this example, the columns in the `SELECT` clause are misaligned, leading to poor readability and an unstructured look.
-
-Best Practice: Consistent Indentation of Columns
+Anti-pattern: Inconsistent Statement Indentation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For better readability, each column in the `SELECT` clause should be consistently indented. The preferred convention is to align the columns vertically to the same starting point, making the query easier to read and maintain.
+When SQL statements are not consistently indented, it becomes difficult to understand the flow and structure of the query. Misaligned statements make it harder to identify which elements belong together, resulting in potential errors during query writing and debugging.
 
-**Refactored Example with Consistent Column Indentation (Best Practice):**
+**Example of Inconsistent Statement Indentation (Anti-pattern):**
 
 .. code-block:: sql
 
-    SELECT t.col1,
-           t.col2,
-           t.col3
-      FROM dataset.table t;
+    select t.col1,
+    t.col2
+    from dataset.table t
+    where t.col1 > 100
+     and t.col2 = 'active';
 
-In this refactored example, the columns are properly indented, with each column aligned vertically and consistently indented. This structure makes the query easier to understand and maintain, and the alignment improves the overall readability.
+In this example, the lack of consistent indentation between the `SELECT`, `FROM`, and `WHERE` clauses reduces readability, making the query appear disorganized and harder to maintain.
+
+Best Practice: Consistent Indentation of Statements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For improved readability and maintainability, all SQL statements should be indented consistently. A common practice is to align columns in the `SELECT` clause vertically, with subsequent clauses (`FROM`, `WHERE`, etc.) indented appropriately. This makes it easier to understand the flow of the query and simplifies maintenance.
+
+**Refactored Example with Consistent Statement Indentation (Best Practice):**
+
+.. code-block:: sql
+
+    select t.col1,
+           t.col2
+      from dataset.table t
+     where t.col1 > 100
+       and t.col2 = 'active';
+
+In this refactored example, the `SELECT`, `FROM`, and `WHERE` clauses are properly indented, and the conditions within the `WHERE` clause are aligned. This creates a more readable and organized query, making it easier to follow and maintain.
 
 Conclusion
 ----------
 
-Consistent indentation of columns in SQL queries improves readability and maintainability, making it easier to understand the query structure at a glance. Following this rule ensures that queries are formatted in a clean and professional manner, reducing the chance of errors and making the code easier to collaborate on.
+Consistent indentation of SQL statements is key to improving query readability and maintainability. Following this rule ensures that SQL queries are structured clearly, making them easier to work with in collaborative environments. Clean and predictable indentation helps developers avoid errors and makes the code easier to understand and maintain.
 
 Groups:
 -------

--- a/docs/source/rules/layout/LT02.rst
+++ b/docs/source/rules/layout/LT02.rst
@@ -1,0 +1,58 @@
+=============================================
+Rule: Columns Should Be Indented Consistently
+=============================================
+
+**Rule Code:** ``LT02``
+
+**Name:** ``indent_select``
+
+Overview
+--------
+
+In SQL queries, consistent indentation of columns improves readability, maintainability, and clarity, especially in longer queries. Proper indentation makes it easier to visually distinguish between different components of the query, such as columns in the `SELECT` clause, and improves the overall organization of the code. Consistently formatting SQL queries also ensures that queries are easier to understand and maintain in collaborative environments.
+
+Explanation
+-----------
+
+Anti-pattern: Inconsistent Column Indentation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Inconsistent indentation of columns in the `SELECT` clause makes queries difficult to read and can lead to confusion, especially when the query grows in complexity. Misaligned columns can make it hard to quickly scan the query and understand the data being selected, which can result in errors during maintenance or debugging.
+
+**Example of Inconsistent Column Indentation (Anti-pattern):**
+
+.. code-block:: sql
+
+    SELECT t.col1,
+    t.col2,
+       t.col3
+    FROM dataset.table t;
+
+In this example, the columns in the `SELECT` clause are misaligned, leading to poor readability and an unstructured look.
+
+Best Practice: Consistent Indentation of Columns
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For better readability, each column in the `SELECT` clause should be consistently indented. The preferred convention is to align the columns vertically to the same starting point, making the query easier to read and maintain.
+
+**Refactored Example with Consistent Column Indentation (Best Practice):**
+
+.. code-block:: sql
+
+    SELECT t.col1,
+           t.col2,
+           t.col3
+      FROM dataset.table t;
+
+In this refactored example, the columns are properly indented, with each column aligned vertically and consistently indented. This structure makes the query easier to understand and maintain, and the alignment improves the overall readability.
+
+Conclusion
+----------
+
+Consistent indentation of columns in SQL queries improves readability and maintainability, making it easier to understand the query structure at a glance. Following this rule ensures that queries are formatted in a clean and professional manner, reducing the chance of errors and making the code easier to collaborate on.
+
+Groups:
+-------
+
+- `all <../..>`_
+- `layout <../..#layout-rules>`_

--- a/server/src/linter/parser/index.ts
+++ b/server/src/linter/parser/index.ts
@@ -340,7 +340,7 @@ export class Parser {
 	 */
 	private parseStatement(tokens: Token[]): StatementAST {
 
-		const statement = new StatementAST();
+		const statement = new StatementAST(tokens);
 
 		if (tokens.length === 0) {
 			return statement;
@@ -351,7 +351,7 @@ export class Parser {
 		let tokenCounter: number = 0;
 		let reCheck: boolean = true; // used to stop infinite loops
 		statement.tokens = tokens;
-		statement.lineNumber = tokens[0].lineNumber;
+		statement.startLine = tokens[0].lineNumber;
 
 		const reset = () => {
 			rules = syntaxJson.rules;

--- a/server/src/linter/rules/aliasing/AL05.ts
+++ b/server/src/linter/rules/aliasing/AL05.ts
@@ -101,7 +101,7 @@ export class UnusedAlias extends Rule<FileMap>{
         if (columnToken) {
           errors.push(this.createDiagnostic({start: {line: columnToken.lineNumber ?? 0, character: columnToken.startIndex ?? 0}, end: {line: columnToken.lineNumber ?? 0, character: columnToken.endIndex ?? 0}}, documentUri));
         } else {
-          errors.push(this.createDiagnostic({start: {line: column.lineNumber ?? 0, character: column.startIndex ?? 0}, end: {line: column.lineNumber ?? 0, character: column.endIndex ?? 0}}, documentUri));
+          errors.push(this.createDiagnostic({start: {line: column.startLine ?? 0, character: column.startIndex ?? 0}, end: {line: column.startLine ?? 0, character: column.endIndex ?? 0}}, documentUri));
         }
       }
     } else if (column instanceof ColumnFunctionAST) {

--- a/server/src/linter/rules/base.ts
+++ b/server/src/linter/rules/base.ts
@@ -129,4 +129,15 @@ export abstract class Rule<T extends string | FileMap>{
 		return url.href;
 	}
 
+
+  /**
+   * Generates a unique cache key based on the provided range.
+   *
+   * @param range - The range object containing start and end positions.
+   * @returns A string that uniquely identifies the range.
+   */
+  createCacheKey(range: Range): string {
+    return `${range.start.line}|${range.start.character}|${range.end.line}|${range.end.character}`;
+  }
+
 }

--- a/server/src/linter/rules/layout/LT02.ts
+++ b/server/src/linter/rules/layout/LT02.ts
@@ -35,7 +35,7 @@ export class IndentSelect extends Rule<FileMap> {
   readonly code: string = "LT02";
   readonly type: RuleType = RuleType.PARSER;
   readonly message: string = "Incorrect Indentation.";
-  readonly relatedInformation: string = "";
+  readonly relatedInformation: string = "Inconsistent indentation of columns in the `SELECT` clause makes queries difficult to read and can lead to confusion, especially when the query grows in complexity.";
   readonly ruleGroup: string = 'layout';
   readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
   readonly codeActionTitle = 'Update Indentation';

--- a/server/src/linter/rules/layout/LT02.ts
+++ b/server/src/linter/rules/layout/LT02.ts
@@ -1,0 +1,159 @@
+/**
+ * @fileoverview Rules to enforce trailing comma checks
+ * @module linter/rules/layout
+ * @requires vscode-languageserver
+ * @requires settings
+ * @requires Rule
+ */
+
+
+import { ServerSettings } from "../../../settings";
+import { RuleType } from '../enums';
+import {
+  CodeAction,
+  CodeActionKind,
+  Diagnostic,
+  DiagnosticSeverity,
+  DocumentUri,
+  TextDocumentIdentifier,
+  TextEdit,
+} from 'vscode-languageserver/node';
+import { Rule } from '../base';
+import { FileMap } from '../../parser';
+
+type RangeCache = Map<string, number>
+const documentCache: Map<DocumentUri, RangeCache> = new Map<DocumentUri, RangeCache>();
+
+/**
+ * The IndentSelect rule
+ * @class IndentSelect
+ * @extends Rule
+ * @memberof Linter.Rules
+ */
+export class IndentSelect extends Rule<FileMap> {
+  readonly name: string = "indent_select";
+  readonly code: string = "LT02";
+  readonly type: RuleType = RuleType.PARSER;
+  readonly message: string = "Incorrect Indentation.";
+  readonly relatedInformation: string = "";
+  readonly ruleGroup: string = 'layout';
+  readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
+  readonly codeActionTitle = 'Update Indentation';
+  readonly severity: DiagnosticSeverity = DiagnosticSeverity.Warning;
+
+  /**
+   * Creates an instance of IndentSelect.
+   * @param {ServerSettings} settings The server settings
+   * @param {number} problems The number of problems identified in the source code
+   * @memberof IndentSelect
+   */
+  constructor(settings: ServerSettings, problems: number) {
+    super(settings, problems);
+  }
+
+  /**
+   * Evaluates the provided Abstract Syntax Tree (AST) to identify and return diagnostics for layout issues.
+   * Specifically, it checks for misplaced commas in the SQL code represented by the AST.
+   *
+   * @param ast - The Abstract Syntax Tree (AST) representing the SQL code to be evaluated.
+   * @param documentUri - The URI of the document being evaluated. This parameter is optional and defaults to null.
+   * @returns An array of `Diagnostic` objects representing the layout issues found, or null if no issues are found or the rule is disabled.
+   */
+  evaluate(ast: FileMap, documentUri: string | null = null): Diagnostic[] | null {
+
+    if (this.enabled === false) {
+      return null;
+    }
+
+    const errors: Diagnostic[] = [];
+    let cache = documentCache.get(documentUri!);
+    if (!cache) {
+      cache = new Map<string, number>();
+    }
+
+    for (const i in ast) {
+      const offset = (ast[i].startIndex??0) + 7;
+      const columns = ast[i].columns;
+
+      columns.map((column) => {
+        if (column.startIndex !== offset) {
+
+          const errorOffset = offset - (column.startIndex??0);
+          let additionalIdentNumber = 0;
+          const errorRange = {
+            start: {
+              line: column.startLine??0,
+              character: column.startIndex??0
+            },
+            end: {
+              line: column.startLine??0,
+              character: column.startIndex??0
+            }
+          }
+
+          if (errorOffset > 0) {
+            // if error offset is greater than 0 then
+            // the column is indented too far to the left
+            // and needs to be moved to the right
+            additionalIdentNumber = errorOffset;
+
+          } else if (errorOffset < 0) {
+            // if error offset is less than 0 then
+            // the column is indented too far to the right
+            // and needs to be moved to the left
+
+            errorRange.start.character = offset;
+
+          }
+
+          errors.push(this.createDiagnostic(
+            errorRange,
+            documentUri
+          ));
+          cache.set(this.createCacheKey(errorRange), additionalIdentNumber);
+        }
+      });
+    }
+
+    documentCache.set(documentUri!, cache);
+
+    return errors.length > 0 ? errors : null;
+  }
+
+  createCodeAction(textDocument: TextDocumentIdentifier, diagnostic: Diagnostic): CodeAction[] {
+    const cachedDocument = documentCache.get(textDocument.uri);
+    let text = '';
+    if (!cachedDocument) {
+      return [];
+    }
+
+    const additionalIdentNumber = cachedDocument.get(this.createCacheKey(diagnostic.range));
+    if (additionalIdentNumber == null) {
+      return [];
+    }
+
+    text = ' '.repeat(additionalIdentNumber) + text;
+  
+    const edit = {
+        changes: {
+            [textDocument.uri]: [
+                TextEdit.replace(diagnostic.range, text)
+            ]
+        }
+    };
+    const actions: CodeAction[] = [];
+    
+    this.codeActionKind.map((kind) => {
+      const fix = CodeAction.create(
+        this.codeActionTitle,
+        edit,
+        kind
+      );
+      fix.diagnostics = [diagnostic];
+      actions.push(fix);
+    });
+
+    return actions;
+  }
+
+}

--- a/server/src/linter/rules/layout/LT02.ts
+++ b/server/src/linter/rules/layout/LT02.ts
@@ -39,7 +39,7 @@ export class Indent extends Rule<FileMap> {
   readonly code: string = "LT02";
   readonly type: RuleType = RuleType.PARSER;
   readonly message: string = "Incorrect Indentation.";
-  readonly relatedInformation: string = "";
+  readonly relatedInformation: string = "For improved readability and maintainability, all SQL statements should be indented consistently.";
   readonly ruleGroup: string = 'layout';
   readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
   readonly codeActionTitle = 'Update Indentation';

--- a/server/src/linter/rules/layout/LT02.ts
+++ b/server/src/linter/rules/layout/LT02.ts
@@ -15,11 +15,15 @@ import {
   Diagnostic,
   DiagnosticSeverity,
   DocumentUri,
+  Range,
   TextDocumentIdentifier,
   TextEdit,
 } from 'vscode-languageserver/node';
 import { Rule } from '../base';
 import { FileMap } from '../../parser';
+import { findToken } from '../../parser/utils';
+import { excludeTokensWithMatchingScopes, includeTokensWithMatchingScopes } from '../../parser/token';
+import { ComparisonAST, ComparisonGroupAST } from '../../parser/ast';
 
 type RangeCache = Map<string, number>
 const documentCache: Map<DocumentUri, RangeCache> = new Map<DocumentUri, RangeCache>();
@@ -30,12 +34,12 @@ const documentCache: Map<DocumentUri, RangeCache> = new Map<DocumentUri, RangeCa
  * @extends Rule
  * @memberof Linter.Rules
  */
-export class IndentSelect extends Rule<FileMap> {
-  readonly name: string = "indent_select";
+export class Indent extends Rule<FileMap> {
+  readonly name: string = "indent";
   readonly code: string = "LT02";
   readonly type: RuleType = RuleType.PARSER;
   readonly message: string = "Incorrect Indentation.";
-  readonly relatedInformation: string = "Inconsistent indentation of columns in the `SELECT` clause makes queries difficult to read and can lead to confusion, especially when the query grows in complexity.";
+  readonly relatedInformation: string = "";
   readonly ruleGroup: string = 'layout';
   readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
   readonly codeActionTitle = 'Update Indentation';
@@ -74,12 +78,54 @@ export class IndentSelect extends Rule<FileMap> {
     for (const i in ast) {
       const offset = (ast[i].startIndex??0) + 7;
       const columns = ast[i].columns;
+      const aliasRanges: Range[] = [];
+      const columnEndIndexes: number[] = [];
+      const from = ast[i].from;
+      const joins = ast[i].joins;
+      const where = ast[i].where;
 
       columns.map((column) => {
+
+        // add alias and index details for later processing
+        if (column.alias) {
+          const aliasToken = findToken(column.tokens, 'entity.name.tag');
+          if (aliasToken) {
+            aliasRanges.push(
+              {
+                start: {
+                  line: aliasToken.lineNumber??0,
+                  character: aliasToken.startIndex
+                },
+                end: {
+                  line: aliasToken.lineNumber??0,
+                  character: aliasToken.endIndex
+                }
+              }
+            );
+          }
+        }
+
+        const columnTokens = excludeTokensWithMatchingScopes(
+          column.tokens,
+          [
+            'entity.name.tag',
+            'punctuation.whitespace.leading.sql',
+            'punctuation.whitespace.trailing.sql',
+            'punctuation.whitespace.sql',
+            'punctuation.separator.comma.sql',
+            'comment.line.double-dash.sql'
+          ]
+        );
+        if (columnTokens.length > 0) {
+          columnEndIndexes.push(columnTokens[columnTokens.length - 1].endIndex);
+        } else {
+          console.log(column);
+        }
+
+        // process leading indentation
         if (column.startIndex !== offset) {
 
           const errorOffset = offset - (column.startIndex??0);
-          let additionalIdentNumber = 0;
           const errorRange = {
             start: {
               line: column.startLine??0,
@@ -91,33 +137,292 @@ export class IndentSelect extends Rule<FileMap> {
             }
           }
 
-          if (errorOffset > 0) {
-            // if error offset is greater than 0 then
-            // the column is indented too far to the left
-            // and needs to be moved to the right
-            additionalIdentNumber = errorOffset;
-
-          } else if (errorOffset < 0) {
-            // if error offset is less than 0 then
-            // the column is indented too far to the right
-            // and needs to be moved to the left
-
-            errorRange.start.character = offset;
-
-          }
+          const [additionalIdentNumber, newRange] = this.createIndentErrorOutputs(
+            offset,
+            errorOffset,
+            errorRange
+          );
 
           errors.push(this.createDiagnostic(
-            errorRange,
+            newRange,
             documentUri
           ));
-          cache.set(this.createCacheKey(errorRange), additionalIdentNumber);
+          cache.set(this.createCacheKey(newRange), additionalIdentNumber);
         }
       });
+
+      const aliasIndex = Math.max(...columnEndIndexes) + 2;
+
+      aliasRanges.map((aliasRange) => {
+        if (aliasRange.start.character !== aliasIndex) {
+
+          const errorOffset = aliasIndex - aliasRange.start.character;
+          const errorRange = {
+            start: {
+              line: aliasRange.start.line,
+              character: aliasRange.start.character
+            },
+            end: {
+              line: aliasRange.start.line,
+              character: aliasRange.start.character
+            }
+          }
+
+          const [additionalIdentNumber, newRange] = this.createIndentErrorOutputs(
+            aliasIndex,
+            errorOffset,
+            errorRange
+          );
+
+          errors.push(this.createDiagnostic(
+            newRange,
+            documentUri
+          ));
+          cache.set(this.createCacheKey(newRange), additionalIdentNumber);
+        }
+      });
+
+      if (from) {
+
+        // identify the source keyword
+        const fromToken = findToken(from.tokens, 'keyword.from.sql');
+        const keywordLength = (fromToken?.value.length??0) + 1;
+        const keywordOffset = offset - keywordLength;
+
+        if (from.startIndex !== keywordOffset) {
+
+          const errorOffset = keywordOffset - (from.startIndex??0);
+          const errorRange = {
+            start: {
+              line: from.startLine??0,
+              character: from.startIndex??0
+            },
+            end: {
+              line: from.startLine??0,
+              character: from.startIndex??0
+            }
+          }
+
+          const [additionalIdentNumber, newRange] = this.createIndentErrorOutputs(
+            keywordOffset,
+            errorOffset,
+            errorRange
+          );
+
+          errors.push(this.createDiagnostic(
+            newRange,
+            documentUri
+          ));
+          cache.set(this.createCacheKey(newRange), additionalIdentNumber);
+        }
+      }
+
+      joins.map((join) => {
+        // find join type
+        const joinParts = join.join?.split(' ');
+        let joinOffset = joinParts != null && joinParts.length > 1 && joinParts[0] === 'left' ? 2 : 1;
+        joinOffset = offset - (offset - joinOffset);
+
+        if (join.startIndex != joinOffset) {
+
+          const errorOffset = joinOffset - (join.startIndex??0);
+          const errorRange = {
+            start: {
+              line: join.startLine??0,
+              character: join.startIndex??0
+            },
+            end: {
+              line: join.startLine??0,
+              character: join.startIndex??0
+            }
+          }
+
+          const [additionalIdentNumber, newRange] = this.createIndentErrorOutputs(
+            joinOffset,
+            errorOffset,
+            errorRange
+          );
+
+          errors.push(this.createDiagnostic(
+            newRange,
+            documentUri
+          ));
+          cache.set(this.createCacheKey(newRange), additionalIdentNumber);
+
+        }
+
+        if (join.on) {
+          const onOffset = offset - 3;
+          if (join.on.startIndex !== onOffset) {
+
+            const errorOffset = onOffset - (join.on.startIndex??0);
+            const errorRange = {
+              start: {
+                line: join.on.startLine??0,
+                character: join.on.startIndex??0
+              },
+              end: {
+                line: join.on.startLine??0,
+                character: join.on.startIndex??0
+              }
+            }
+
+            const [additionalIdentNumber, newRange] = this.createIndentErrorOutputs(
+              onOffset,
+              errorOffset,
+              errorRange
+            );
+
+            errors.push(this.createDiagnostic(
+              newRange,
+              documentUri
+            ));
+            cache.set(this.createCacheKey(newRange), additionalIdentNumber);
+          }
+
+          // process comparison groups
+          const comparisonResults = this.processComparisons(join.on.comparisons, offset);
+          comparisonResults.map((result) => {
+            const [additionalIdentNumber, newRange] = result;
+            errors.push(this.createDiagnostic(
+              newRange,
+              documentUri
+            ));
+            cache.set(this.createCacheKey(newRange), additionalIdentNumber);
+          });
+        }
+      });
+
+      if (where) {
+        const whereToken = findToken(where.tokens, 'keyword.where.sql');
+        const whereOffset = offset - (offset - 1);
+
+        if (where.startIndex !== whereOffset) {
+
+          const errorOffset = whereOffset - (where.startIndex??0);
+          const errorRange = {
+            start: {
+              line: whereToken?.lineNumber??0,
+              character: whereToken?.startIndex??0
+            },
+            end: {
+              line: whereToken?.lineNumber??0,
+              character: whereToken?.startIndex??0
+            }
+          }
+
+          const [additionalIdentNumber, newRange] = this.createIndentErrorOutputs(
+            whereOffset,
+            errorOffset,
+            errorRange
+          );
+
+          errors.push(this.createDiagnostic(
+            newRange,
+            documentUri
+          ));
+          cache.set(this.createCacheKey(newRange), additionalIdentNumber);
+        }
+
+        // process comparison groups
+        const comparisonResults = this.processComparisons(where.comparisons, offset);
+        comparisonResults.map((result) => {
+          const [additionalIdentNumber, newRange] = result;
+          errors.push(this.createDiagnostic(
+            newRange,
+            documentUri
+          ));
+          cache.set(this.createCacheKey(newRange), additionalIdentNumber);
+        });
+      }
     }
 
     documentCache.set(documentUri!, cache);
 
     return errors.length > 0 ? errors : null;
+  }
+
+  /**
+   * Processes an array of comparisons and returns an array of tuples containing
+   * an additional indent number and a range for each comparison that does not
+   * match the expected offset.
+   *
+   * @param comparisons - An array of ComparisonAST or ComparisonGroupAST objects to process.
+   * @param offset - The initial offset to use for comparison.
+   * @returns An array of tuples where each tuple contains:
+   *   - A number representing the additional indent required.
+   *   - A Range object indicating the start and end positions of the error.
+   */
+  private processComparisons(comparisons: (ComparisonAST | ComparisonGroupAST)[], offset: number): [number, Range][] {
+    const results: [number, Range][] = [];
+    comparisons.map((comparison) => {
+      let comparisonOffset = offset;
+
+      if (comparison instanceof ComparisonAST) {
+        const operator = comparison.logicalOperator;
+        if (operator) {
+          // adjust offset based on operator
+          const operatorAdjustment = operator.toLowerCase() === 'and' ? 4 : 3;
+          comparisonOffset = offset - operatorAdjustment;
+        }
+        
+        if (comparison.startIndex !== comparisonOffset) {
+
+          const errorOffset = comparisonOffset - (comparison.startIndex??0);
+          const errorRange = {
+            start: {
+              line: comparison.startLine??0,
+              character: comparison.startIndex??0
+            },
+            end: {
+              line: comparison.startLine??0,
+              character: comparison.startIndex??0
+            }
+          }
+
+          const [additionalIdentNumber, newRange] = this.createIndentErrorOutputs(
+            comparisonOffset,
+            errorOffset,
+            errorRange
+          );
+
+          results.push([additionalIdentNumber, newRange]);
+        }
+      } else if (comparison instanceof ComparisonGroupAST) {
+        comparisonOffset = comparisonOffset + 5;
+        results.push(...this.processComparisons(comparison.comparisons, comparisonOffset));
+      }
+    });
+    return results;
+  }
+
+  /**
+   * Creates error outputs for indentation issues.
+   *
+   * @param offset - The current offset of the indentation.
+   * @param errorOffset - The offset indicating how much the indentation is off by.
+   * @param errorRange - The range object representing the start and end positions of the error.
+   * @returns A tuple containing the additional indent number and the updated error range.
+   */
+  private createIndentErrorOutputs(offset: number, errorOffset: number, errorRange: Range): [number, Range] {
+    let additionalIdentNumber = 0;
+
+    if (errorOffset > 0) {
+      // if error offset is greater than 0 then
+      // the column is indented too far to the left
+      // and needs to be moved to the right
+      additionalIdentNumber = errorOffset;
+
+    } else if (errorOffset < 0) {
+      // if error offset is less than 0 then
+      // the column is indented too far to the right
+      // and needs to be moved to the left
+
+      errorRange.start.character = offset;
+
+    }
+
+    return [additionalIdentNumber, errorRange];
   }
 
   createCodeAction(textDocument: TextDocumentIdentifier, diagnostic: Diagnostic): CodeAction[] {

--- a/server/src/linter/rules/layout/LT09.ts
+++ b/server/src/linter/rules/layout/LT09.ts
@@ -92,14 +92,14 @@ export class SelectTargets extends Rule<FileMap> {
           continue;
         }
 
-        if (current.lineNumber === next.lineNumber) {
+        if (current.startLine === next.startLine) {
           errors.push(this.createDiagnostic({
             start: {
-              line: current.lineNumber??0,
+              line: current.startLine??0,
               character: current.startIndex??0
             },
             end: {
-              line: next.lineNumber??0,
+              line: next.startLine??0,
               character: next.endIndex??0
             }
           }, documentUri));

--- a/server/src/linter/rules/layout/LT12.ts
+++ b/server/src/linter/rules/layout/LT12.ts
@@ -10,7 +10,7 @@
 import { CodeAction, CodeActionKind, Diagnostic, TextDocumentIdentifier, TextEdit } from 'vscode-languageserver';
 import { Rule } from '../base';
 
-export class EndofFile extends Rule<string> {
+export class EndOfFile extends Rule<string> {
 	readonly name: string = "end_of_file";
 	readonly code: string = "LT12";
 	readonly message: string = "Files must end with a single trailing newline.";

--- a/server/src/linter/rules/layout/LT15.ts
+++ b/server/src/linter/rules/layout/LT15.ts
@@ -146,16 +146,6 @@ export class ComparisonOperators extends Rule<FileMap> {
     return errors;
 
   }
-
-  /**
-   * Generates a unique cache key based on the provided range.
-   *
-   * @param range - The range object containing start and end positions.
-   * @returns A string that uniquely identifies the range.
-   */
-  private createCacheKey(range: Range): string {
-    return `${range.start.line}|${range.start.character}|${range.end.line}|${range.end.character}`;
-  }
   
   /**
    * Creates a set of code actions to fix diagnostics.

--- a/server/src/linter/rules/layout/rules.ts
+++ b/server/src/linter/rules/layout/rules.ts
@@ -9,24 +9,26 @@
 import { Rule } from '../base';
 import { ServerSettings } from '../../../settings';
 import { TrailingSpaces } from './LT01';
+import { IndentSelect } from './LT02';
 import { TrailingComma } from './LT04';
 import { Functions } from './LT06';
 import { SelectTargets } from './LT09';
 import { SelectModifiers } from './LT10';
 import { UnionCheck } from './LT11';
-import { EndofFile } from './LT12';
+import { EndOfFile } from './LT12';
 import { StartOfFile } from './LT13';
 import { ComparisonOperators } from './LT15';
 import { FileMap } from '../../parser';
 
-export const classes = [SelectModifiers,
-												SelectTargets,
-                        UnionCheck,
+export const classes = [TrailingSpaces,
+												IndentSelect,
 												TrailingComma,
-                        EndofFile,
-                        StartOfFile,
-                        TrailingSpaces,
 												Functions,
+												SelectTargets,
+												SelectModifiers,
+												UnionCheck,
+												EndOfFile,
+												StartOfFile,
 												ComparisonOperators];
 
 export function layoutRules(settings: ServerSettings, problems: number): Rule<string | FileMap>[] {

--- a/server/src/linter/rules/layout/rules.ts
+++ b/server/src/linter/rules/layout/rules.ts
@@ -9,7 +9,7 @@
 import { Rule } from '../base';
 import { ServerSettings } from '../../../settings';
 import { TrailingSpaces } from './LT01';
-import { IndentSelect } from './LT02';
+import { Indent } from './LT02';
 import { TrailingComma } from './LT04';
 import { Functions } from './LT06';
 import { SelectTargets } from './LT09';
@@ -21,7 +21,7 @@ import { ComparisonOperators } from './LT15';
 import { FileMap } from '../../parser';
 
 export const classes = [TrailingSpaces,
-												IndentSelect,
+												Indent,
 												TrailingComma,
 												Functions,
 												SelectTargets,

--- a/server/src/linter/syntaxes/googlesql.tmLanguage.json
+++ b/server/src/linter/syntaxes/googlesql.tmLanguage.json
@@ -521,7 +521,7 @@
             "8": { "name": "keyword.as.sql" },
             "9": { "name": "entity.name.alias.sql" }
           },
-          "match": "(?i)(?:(from)|((?:(?:(?:inner|cross|(?:left|right|full)(?:\\s+outer)?)\\s+)join)))(?:\\s+(`?)(?:([\\w_]+)\\.)?(?:([\\w_]+)\\.([\\w_]+))(`?)(?:\\s+(?:(as)\\s+)?([\\w_]+))?)",
+          "match": "(?i)(?:(from|update)|((?:(?:(?:inner|cross|(?:left|right|full)(?:\\s+outer)?)\\s+)join)))(?:\\s+(`?)(?:([\\w_]+)\\.)?(?:([\\w_]+)\\.([\\w_]+))(`?)(?:\\s+(?:(as)\\s+)?([\\w_]+))?)",
           "name": "meta.source.sql"
         },
         {

--- a/server/src/tests/linter/linter.test.ts
+++ b/server/src/tests/linter/linter.test.ts
@@ -37,13 +37,13 @@ describe('Linter', () => {
     });
 
     it('should ignore rules for lines with directives', async () => {
-        const source = {text:'select case when cc.enddate is null then 1 else null end as is_current, -- noqa\nfrom dataset.table cc;\n', uri: 'test.sql', languageId: 'sql', version: 0};
+        const source = {text:'select case when cc.enddate is null then 1 else null end as is_current, -- noqa\n  from dataset.table cc;\n', uri: 'test.sql', languageId: 'sql', version: 0};
         const result = await linter.verify(source);
         expect(result.length).to.be.equal(0);
     });
 
     it('should ignore only rules mentioned for lines with directives', async () => {
-        const source = {text:'select case when cc.enddate is null then 1 else null end as is_current, -- noqa: ST01\nfrom dataset.table cc;\n', uri: 'test.sql', languageId: 'sql', version: 0};
+        const source = {text:'select case when cc.enddate is null then 1 else null end as  is_current -- noqa: ST01\n  from dataset.table cc;\n', uri: 'test.sql', languageId: 'sql', version: 0};
         const result = await linter.verify(source);
         expect(result.length).to.be.equal(1);
     });

--- a/server/src/tests/linter/parser/ast.test.ts
+++ b/server/src/tests/linter/parser/ast.test.ts
@@ -12,7 +12,7 @@ describe('StringAST Class', () => {
         expect(stringAST.tokens).to.deep.equal(tokens);
         expect(stringAST.value).to.equal('value1value2');
         expect(stringAST.alias).to.be.null;
-        expect(stringAST.lineNumber).to.equal(1);
+        expect(stringAST.startLine).to.equal(1);
         expect(stringAST.startIndex).to.equal(0);
         expect(stringAST.endIndex).to.equal(10);
     });
@@ -23,7 +23,7 @@ describe('StringAST Class', () => {
         expect(stringAST.tokens).to.deep.equal(tokens);
         expect(stringAST.value).to.be.null;
         expect(stringAST.alias).to.be.null;
-        expect(stringAST.lineNumber).to.be.null;
+        expect(stringAST.startLine).to.be.null;
         expect(stringAST.startIndex).to.be.null;
         expect(stringAST.endIndex).to.be.null;
     });
@@ -38,7 +38,7 @@ describe('StringAST Class', () => {
         expect(stringAST.tokens).to.deep.equal(tokens);
         expect(stringAST.value).to.equal('value1value2value3');
         expect(stringAST.alias).to.be.null;
-        expect(stringAST.lineNumber).to.equal(1);
+        expect(stringAST.startLine).to.equal(1);
         expect(stringAST.startIndex).to.equal(0);
         expect(stringAST.endIndex).to.equal(15);
     });

--- a/server/src/tests/linter/rules/layout/LT02.test.ts
+++ b/server/src/tests/linter/rules/layout/LT02.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @fileoverview Test suite for LT04 module
+ */
+
+import { expect } from 'chai';
+import { defaultSettings } from '../../../../settings';
+import { IndentSelect } from '../../../../linter/rules/layout/LT02';
+import { FileMap, Parser } from '../../../../linter/parser';
+import { StatementAST } from '../../../../linter/parser/ast';
+
+describe('IndentSelect', () => {
+    let instance: IndentSelect;
+
+    beforeEach(() => {
+        instance = new IndentSelect(defaultSettings, 0);
+    });
+
+    it('should return null when rule is disabled', () => {
+        instance.enabled = false;
+        const result = instance.evaluate({1: new StatementAST()} as FileMap);
+        expect(result).to.be.null;
+    });
+
+    it('should return diagnostic when rule is enabled and comma is at start of line', async () => {
+        instance.enabled = true;
+
+
+        const parser = new Parser();
+
+        const result = instance.evaluate(await parser.parse({text:'select t.col1,\nt.col2,\n  from dataset.table t\n;\n', uri: 'test.sql', languageId: 'sql', version: 0}));
+        expect(result).to.deep.equal([{
+            code: instance.diagnosticCode,
+            codeDescription: {href: instance.diagnosticCodeDescription},
+            message: instance.message,
+            severity: instance.severity,
+            range: {
+                start: { line: 1, character: 0 },
+                end: { line: 1, character: 0 }
+            },
+            source: instance.source
+        }]);
+    });
+
+    it('should return null when rule is enabled but pattern does not match', async () => {
+        instance.enabled = true;
+
+        const parser = new Parser();
+
+        const result = instance.evaluate(await parser.parse({text:'select t.col1,\n       t.col2,\n  from dataset.table t\n;\n', uri: 'test.sql', languageId: 'sql', version: 0}));
+        expect(result).to.be.null;
+    });
+});

--- a/server/src/tests/linter/rules/layout/LT02.test.ts
+++ b/server/src/tests/linter/rules/layout/LT02.test.ts
@@ -4,15 +4,15 @@
 
 import { expect } from 'chai';
 import { defaultSettings } from '../../../../settings';
-import { IndentSelect } from '../../../../linter/rules/layout/LT02';
+import { Indent } from '../../../../linter/rules/layout/LT02';
 import { FileMap, Parser } from '../../../../linter/parser';
 import { StatementAST } from '../../../../linter/parser/ast';
 
 describe('IndentSelect', () => {
-    let instance: IndentSelect;
+    let instance: Indent;
 
     beforeEach(() => {
-        instance = new IndentSelect(defaultSettings, 0);
+        instance = new Indent(defaultSettings, 0);
     });
 
     it('should return null when rule is disabled', () => {

--- a/server/src/tests/linter/rules/layout/LT02.test.ts
+++ b/server/src/tests/linter/rules/layout/LT02.test.ts
@@ -27,7 +27,7 @@ describe('IndentSelect', () => {
 
         const parser = new Parser();
 
-        const result = instance.evaluate(await parser.parse({text:'select t.col1,\nt.col2,\n  from dataset.table t\n;\n', uri: 'test.sql', languageId: 'sql', version: 0}));
+        const result = instance.evaluate(await parser.parse({text:'select t.col1,\nt.col2,\n  from dataset.table t\nleft join dataset.table r\n on t.col = r.col\nwhere 1 = 1\nand 2 = 2;\n', uri: 'test.sql', languageId: 'sql', version: 0}));
         expect(result).to.deep.equal([{
             code: instance.diagnosticCode,
             codeDescription: {href: instance.diagnosticCodeDescription},
@@ -36,6 +36,72 @@ describe('IndentSelect', () => {
             range: {
                 start: { line: 1, character: 0 },
                 end: { line: 1, character: 0 }
+            },
+            source: instance.source
+        },
+        {
+            code: instance.diagnosticCode,
+            codeDescription: {href: instance.diagnosticCodeDescription},
+            message: instance.message,
+            severity: instance.severity,
+            range: {
+                start: { line: 3, character: 0 },
+                end: { line: 3, character: 0 }
+            },
+            source: instance.source
+        },
+        {
+            code: instance.diagnosticCode,
+            codeDescription: {href: instance.diagnosticCodeDescription},
+            message: instance.message,
+            severity: instance.severity,
+            range: {
+                start: { line: 4, character: 1 },
+                end: { line: 4, character: 1 }
+            },
+            source: instance.source
+        },
+        {
+            code: instance.diagnosticCode,
+            codeDescription: {href: instance.diagnosticCodeDescription},
+            message: instance.message,
+            severity: instance.severity,
+            range: {
+                start: { line: 4, character: 4 },
+                end: { line: 4, character: 4 }
+            },
+            source: instance.source
+        },
+        {
+            code: instance.diagnosticCode,
+            codeDescription: {href: instance.diagnosticCodeDescription},
+            message: instance.message,
+            severity: instance.severity,
+            range: {
+                start: { line: 5, character: 0 },
+                end: { line: 5, character: 0 }
+            },
+            source: instance.source
+        },
+        {
+            code: instance.diagnosticCode,
+            codeDescription: {href: instance.diagnosticCodeDescription},
+            message: instance.message,
+            severity: instance.severity,
+            range: {
+                start: { line: 5, character: 6 },
+                end: { line: 5, character: 6 }
+            },
+            source: instance.source
+        },
+        {
+            code: instance.diagnosticCode,
+            codeDescription: {href: instance.diagnosticCodeDescription},
+            message: instance.message,
+            severity: instance.severity,
+            range: {
+                start: { line: 6, character: 0 },
+                end: { line: 6, character: 0 }
             },
             source: instance.source
         }]);

--- a/server/src/tests/linter/rules/layout/LT12.test.ts
+++ b/server/src/tests/linter/rules/layout/LT12.test.ts
@@ -4,14 +4,14 @@
 
 import { expect } from 'chai';
 import { defaultSettings } from '../../../../settings';
-import { EndofFile } from '../../../../linter/rules/layout/LT12';
+import { EndOfFile } from '../../../../linter/rules/layout/LT12';
 import { Parser } from '../../../../linter/parser';
 
 describe('EndofFile', () => {
-		let instance: EndofFile;
+		let instance: EndOfFile;
 
 		beforeEach(() => {
-				instance = new EndofFile(defaultSettings, 0);
+				instance = new EndOfFile(defaultSettings, 0);
 		});
 
 		it('should return null when rule is disabled', () => {


### PR DESCRIPTION
This pull request adds the LT02 rule to enforce consistent statement indentation in SQL queries. Inconsistent statement indentation can make queries harder to read and maintain. The rule ensures that all SQL statements are indented consistently, improving code readability and making it easier to understand the structure of the query. The pull request also includes relevant code changes and updates to the documentation.

<!-- readthedocs-preview bigquerysqlformatter start -->
----
📚 Documentation preview 📚: https://bigquerysqlformatter--218.org.readthedocs.build/en/218/

<!-- readthedocs-preview bigquerysqlformatter end -->