### PR TITLE
Add CV03 rule for trailing comma within select clause

### DIFF
--- a/docs/source/rules/convention/CV03.rst
+++ b/docs/source/rules/convention/CV03.rst
@@ -1,0 +1,56 @@
+===========================================================
+Rule: Select Statements Should Not Include a Trailing Comma
+===========================================================
+
+**Rule Code:** ``CV03``
+
+**Name:** ``select_trailing_comma``
+
+Overview
+--------
+
+In SQL queries, select statements should not include a trailing comma after the last column or expression in the `SELECT` clause. A trailing comma serves no functional purpose and can lead to errors in certain SQL engines. Removing trailing commas improves readability and consistency while ensuring the query runs smoothly across different environments. Queries should always follow this best practice to avoid potential issues and maintain clean, concise code.
+
+Explanation
+-----------
+
+Anti-pattern: Including a Trailing Comma in `SELECT` Statements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Including a trailing comma after the last column in a `SELECT` statement is an anti-pattern because it can cause syntax errors or lead to confusion, especially when the query is edited or extended. Trailing commas make the code appear incomplete and can break SQL parsers in certain environments.
+
+**Example of Trailing Comma in `SELECT` (Anti-pattern):**
+
+.. code-block:: sql
+
+    select t.col1,
+           t.col2,
+      from dataset.table t;
+
+In this example, there is a trailing comma after `t.col2`, which can result in a syntax error or make the query harder to maintain.
+
+Best Practice: Avoid Trailing Comma in `SELECT` Statements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To ensure better readability and prevent errors, the trailing comma should be omitted in `SELECT` statements. The list of columns or expressions should end with the last meaningful item, without an unnecessary comma.
+
+**Refactored Example Without Trailing Comma (Best Practice):**
+
+.. code-block:: sql
+
+    select t.col1,
+           t.col2
+      from dataset.table t;
+
+In this refactored example, the trailing comma has been removed, resulting in a cleaner and more correct SQL query.
+
+Conclusion
+----------
+
+Avoiding trailing commas in `SELECT` statements is essential for maintaining clean and error-free SQL code. Following this rule ensures that queries are compatible across different databases, reduces potential syntax errors, and promotes consistent formatting in SQL queries.
+
+Groups:
+-------
+
+- `all <../..>`_
+- `convention <../..#convention-rules>`_

--- a/server/src/linter/rules/convention/CV03.ts
+++ b/server/src/linter/rules/convention/CV03.ts
@@ -1,0 +1,83 @@
+import { ServerSettings } from "../../../settings";
+import { CodeAction, CodeActionKind, Diagnostic, DiagnosticSeverity, TextDocumentIdentifier, TextEdit } from 'vscode-languageserver/node';
+import { Rule } from '../base';
+
+
+/**
+ * The SelectTrailingComma rule
+ * @class SelectTrailingComma
+ * @extends Rule
+ * @memberof Linter.Rules
+ */
+export class SelectTrailingComma extends Rule<string> {
+  readonly name: string = "select_trailing_comma";
+  readonly code: string = "CV03";
+  readonly message: string = "Trailing comma within select clause.";
+	readonly relatedInformation: string = "To ensure better readability and prevent errors, the trailing comma should be omitted in `SELECT` statements.";
+  readonly pattern: RegExp = /(,)\s*from/gmi;
+  readonly severity: DiagnosticSeverity = DiagnosticSeverity.Warning;
+  readonly ruleGroup: string = 'convention';
+  readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
+  readonly codeActionTitle = 'Remove trailing comma';
+
+  /**
+   * Creates an instance of SelectTrailingComma.
+   * @param {ServerSettings} settings The server settings
+   * @param {number} problems The number of problems identified in the source code
+   * @memberof SelectTrailingComma
+   */
+  constructor(settings: ServerSettings, problems: number) {
+    super(settings, problems);
+  }
+
+  /**
+   * Evaluates the given test string against a pattern and returns diagnostics if the pattern matches.
+   *
+   * @param test - The string to be tested against the pattern.
+   * @param documentUri - The URI of the document being evaluated, optional.
+   * @returns An array of diagnostics if the pattern matches, otherwise null.
+   */
+  evaluate(test: string, documentUri: string | null = null): Diagnostic[] | null {
+
+    if (this.enabled === false) {
+      return null;
+    }
+
+    if (this.pattern.test(test)) {
+      return this.evaluateRegexPatterns(test, documentUri);
+    }
+
+    return null;
+
+  }
+  
+  /**
+   * Creates a set of code actions to fix diagnostics.
+   *
+   * @param textDocument - The identifier of the text document where the diagnostic was reported.
+   * @param diagnostic - The diagnostic information about the issue to be fixed.
+   * @returns An array of code actions that can be applied to fix the issue.
+   */
+  createCodeAction(textDocument: TextDocumentIdentifier, diagnostic: Diagnostic): CodeAction[] {
+    const edit = {
+        changes: {
+            [textDocument.uri]: [
+                TextEdit.replace(diagnostic.range, '')
+            ]
+        }
+    };
+    const actions: CodeAction[] = [];
+    
+    this.codeActionKind.map((kind) => {
+      const fix = CodeAction.create(
+        this.codeActionTitle,
+        edit,
+        kind
+      );
+      fix.diagnostics = [diagnostic];
+      actions.push(fix);
+    });
+
+    return actions;
+  }
+}

--- a/server/src/linter/rules/convention/rules.ts
+++ b/server/src/linter/rules/convention/rules.ts
@@ -10,6 +10,7 @@ import { Rule } from '../base';
 import { ServerSettings } from '../../../settings';
 import { NotEqual } from './CV01';
 import { Coalesce } from './CV02';
+import { SelectTrailingComma } from './CV03';
 import { Count } from './CV04';
 import { IsNull } from './CV05';
 import { LeftJoin } from './CV08';
@@ -18,6 +19,7 @@ import { FileMap } from '../../parser';
 
 export const classes = [NotEqual,
 												Coalesce,
+												SelectTrailingComma,
 												Count,
 												IsNull,
 												LeftJoin,

--- a/server/src/tests/linter/rules/convention/CV03.test.ts
+++ b/server/src/tests/linter/rules/convention/CV03.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @fileoverview Test suite for LT13 module
+ */
+
+import { expect } from 'chai';
+import { defaultSettings } from '../../../../settings';
+import { SelectTrailingComma } from '../../../../linter/rules/convention/CV03';
+import { Parser } from '../../../../linter/parser';
+
+describe('SelectTrailingComma', () => {
+    let instance: SelectTrailingComma;
+
+    beforeEach(() => {
+        instance = new SelectTrailingComma(defaultSettings, 0);
+    });
+
+    it('should return null when rule is disabled', () => {
+        instance.enabled = false;
+        const result = instance.evaluate('test');
+        expect(result).to.be.null;
+    });
+
+    it('should return diagnostic when rule is enabled and pattern matches', () => {
+        instance.enabled = true;
+        const result = instance.evaluate('select a.col, b.col, from dataset.table a left join dataset.table b on a.col = b.col');
+        expect(result).to.deep.equal([{
+            code: instance.diagnosticCode,
+            codeDescription: {href: instance.diagnosticCodeDescription},
+            message: instance.message,
+            severity: instance.severity,
+            range: {
+                start: { line: 0, character: 19 },
+                end: { line: 0, character: 20 }
+            },
+            source: instance.source
+        }]);
+    });
+
+    it('should return codeaction when rule is enabled and as used', async () => {
+        instance.enabled = true;
+        const parser = new Parser();
+        await parser.parse({text:'select a.col, b.col, from dataset.table a left join dataset.table b on a.col = b.col', uri: 'test.sql', languageId: 'sql', version: 0});
+        const diagnostics = instance.evaluate('select a.col, b.col, from dataset.table a left join dataset.table b on a.col = b.col');
+        const actions = instance.createCodeAction({uri: 'test.sql'}, diagnostics![0]);
+        expect(actions).to.deep.equal(instance.codeActionKind.map(kind => {
+            return {
+                title: instance.codeActionTitle, edit:{
+                changes: {
+                        ['test.sql']: [
+                            {
+                                newText: '',
+                                range: {
+                                    start: { line: 0, character: 19 },
+                                    end: { line: 0, character: 20 }
+                                }
+                            }
+                        ]
+                    }
+                },
+                kind: kind,
+                diagnostics: diagnostics
+            };
+        }));
+    });
+
+    it('should return null when rule is enabled but pattern does not match', () => {
+        instance.enabled = true;
+        const result = instance.evaluate('select a.col, b.col from dataset.table a left join dataset.table b on a.col = b.col');
+        expect(result).to.be.null;
+    });
+});


### PR DESCRIPTION
This pull request adds a new rule, CV03, which checks for trailing commas within select clauses in SQL queries. The rule ensures that select statements do not include a trailing comma after the last column or expression in the SELECT clause. The presence of a trailing comma can cause syntax errors or confusion, and removing it improves readability and consistency. The pull request includes the necessary code changes to implement the rule, including the addition of a new class, SelectTrailingComma, and its integration into the existing rule classes. Additionally, a test suite for the new rule is included to verify its functionality.

<!-- readthedocs-preview bigquerysqlformatter start -->
----
📚 Documentation preview 📚: https://bigquerysqlformatter--219.org.readthedocs.build/en/219/

<!-- readthedocs-preview bigquerysqlformatter end -->