### PR TITLE
Improve "Align equal" rule indentation

### DIFF
--- a/server/src/linter/rules/base.ts
+++ b/server/src/linter/rules/base.ts
@@ -140,4 +140,36 @@ export abstract class Rule<T extends string | FileMap>{
     return `${range.start.line}|${range.start.character}|${range.end.line}|${range.end.character}`;
   }
 
+
+
+  /**
+   * Creates error outputs for indentation issues.
+   *
+   * @param offset - The current offset of the indentation.
+   * @param errorOffset - The offset indicating how much the indentation is off by.
+   * @param errorRange - The range object representing the start and end positions of the error.
+   * @returns A tuple containing the additional indent number and the updated error range.
+   */
+  createIndentErrorOutputs(offset: number, errorOffset: number, errorRange: Range): [number, Range] {
+    let additionalIdentNumber = 0;
+
+    if (errorOffset > 0) {
+      // if error offset is greater than 0 then
+      // the column is indented too far to the left
+      // and needs to be moved to the right
+      additionalIdentNumber = errorOffset;
+
+    } else if (errorOffset < 0) {
+      // if error offset is less than 0 then
+      // the column is indented too far to the right
+      // and needs to be moved to the left
+
+      // errorRange.start.character = offset;
+			errorRange.start.character = errorRange.start.character + errorOffset;
+
+    }
+
+    return [additionalIdentNumber, errorRange];
+  }
+
 }

--- a/server/src/linter/rules/base.ts
+++ b/server/src/linter/rules/base.ts
@@ -150,7 +150,7 @@ export abstract class Rule<T extends string | FileMap>{
    * @param errorRange - The range object representing the start and end positions of the error.
    * @returns A tuple containing the additional indent number and the updated error range.
    */
-  createIndentErrorOutputs(offset: number, errorOffset: number, errorRange: Range): [number, Range] {
+  createIndentErrorOutputs(errorOffset: number, errorRange: Range): [number, Range] {
     let additionalIdentNumber = 0;
 
     if (errorOffset > 0) {

--- a/server/src/linter/rules/layout/LT02.ts
+++ b/server/src/linter/rules/layout/LT02.ts
@@ -396,35 +396,6 @@ export class Indent extends Rule<FileMap> {
     return results;
   }
 
-  /**
-   * Creates error outputs for indentation issues.
-   *
-   * @param offset - The current offset of the indentation.
-   * @param errorOffset - The offset indicating how much the indentation is off by.
-   * @param errorRange - The range object representing the start and end positions of the error.
-   * @returns A tuple containing the additional indent number and the updated error range.
-   */
-  private createIndentErrorOutputs(offset: number, errorOffset: number, errorRange: Range): [number, Range] {
-    let additionalIdentNumber = 0;
-
-    if (errorOffset > 0) {
-      // if error offset is greater than 0 then
-      // the column is indented too far to the left
-      // and needs to be moved to the right
-      additionalIdentNumber = errorOffset;
-
-    } else if (errorOffset < 0) {
-      // if error offset is less than 0 then
-      // the column is indented too far to the right
-      // and needs to be moved to the left
-
-      errorRange.start.character = offset;
-
-    }
-
-    return [additionalIdentNumber, errorRange];
-  }
-
   createCodeAction(textDocument: TextDocumentIdentifier, diagnostic: Diagnostic): CodeAction[] {
     const cachedDocument = documentCache.get(textDocument.uri);
     let text = '';
@@ -460,5 +431,4 @@ export class Indent extends Rule<FileMap> {
 
     return actions;
   }
-
 }

--- a/server/src/linter/rules/layout/LT02.ts
+++ b/server/src/linter/rules/layout/LT02.ts
@@ -138,7 +138,6 @@ export class Indent extends Rule<FileMap> {
           }
 
           const [additionalIdentNumber, newRange] = this.createIndentErrorOutputs(
-            offset,
             errorOffset,
             errorRange
           );
@@ -169,7 +168,6 @@ export class Indent extends Rule<FileMap> {
           }
 
           const [additionalIdentNumber, newRange] = this.createIndentErrorOutputs(
-            aliasIndex,
             errorOffset,
             errorRange
           );
@@ -204,7 +202,6 @@ export class Indent extends Rule<FileMap> {
           }
 
           const [additionalIdentNumber, newRange] = this.createIndentErrorOutputs(
-            keywordOffset,
             errorOffset,
             errorRange
           );
@@ -238,7 +235,6 @@ export class Indent extends Rule<FileMap> {
           }
 
           const [additionalIdentNumber, newRange] = this.createIndentErrorOutputs(
-            joinOffset,
             errorOffset,
             errorRange
           );
@@ -268,7 +264,6 @@ export class Indent extends Rule<FileMap> {
             }
 
             const [additionalIdentNumber, newRange] = this.createIndentErrorOutputs(
-              onOffset,
               errorOffset,
               errorRange
             );
@@ -312,7 +307,6 @@ export class Indent extends Rule<FileMap> {
           }
 
           const [additionalIdentNumber, newRange] = this.createIndentErrorOutputs(
-            whereOffset,
             errorOffset,
             errorRange
           );
@@ -381,7 +375,6 @@ export class Indent extends Rule<FileMap> {
           }
 
           const [additionalIdentNumber, newRange] = this.createIndentErrorOutputs(
-            comparisonOffset,
             errorOffset,
             errorRange
           );

--- a/server/src/linter/rules/layout/LT15.ts
+++ b/server/src/linter/rules/layout/LT15.ts
@@ -137,7 +137,7 @@ export class ComparisonOperators extends Rule<FileMap> {
             character: operator.startIndex
           }
         }
-        const [additionalIdentNumber, newRange] = this.createIndentErrorOutputs(requiredIndex, errorOffset, errorRange);
+        const [additionalIdentNumber, newRange] = this.createIndentErrorOutputs(errorOffset, errorRange);
         errors.push(this.createDiagnostic(newRange, documentUri));
         cache!.set(this.createCacheKey(newRange), additionalIdentNumber);
       }

--- a/server/src/linter/syntaxes/googlesql.tmLanguage.json
+++ b/server/src/linter/syntaxes/googlesql.tmLanguage.json
@@ -722,7 +722,7 @@
           "captures": {
             "1": { "name": "keyword.operator.comparison.sql" }
           },
-          "match": "([!<>]?=|<>|<|>)",
+          "match": "((?:[!<>] *)?=|<>|<|>)",
           "name": "meta.comparison.sql"
         },
         {

--- a/server/src/tests/linter/rules/layout/LT15.test.ts
+++ b/server/src/tests/linter/rules/layout/LT15.test.ts
@@ -32,7 +32,7 @@ describe('ComparisonOperators', () => {
 						severity: instance.severity,
 						range: {
 								start: { line: 2, character: 9 },
-								end: { line: 2, character: 10 }
+								end: { line: 2, character: 9 }
 						},
 						source: instance.source
 				},
@@ -43,7 +43,7 @@ describe('ComparisonOperators', () => {
 						severity: instance.severity,
 						range: {
 								start: { line: 3, character: 10 },
-								end: { line: 3, character: 11 }
+								end: { line: 3, character: 10 }
 						},
 						source: instance.source
 				}]);
@@ -52,33 +52,22 @@ describe('ComparisonOperators', () => {
 		it('should return null when rule is enabled but pattern does not match - where', async () => {
 				instance.enabled = true;
 				const parser = new Parser();
-				const result = instance.evaluate(await parser.parse({text:'select *\n  from dataset.table\n where 1  = 1\n   and 10 = 1', uri: 'test.sql', languageId: 'sql', version: 0}));
+				const result = instance.evaluate(await parser.parse({text:'select *\n  from dataset.table\n where 1   = 1\n   and 10  = 1', uri: 'test.sql', languageId: 'sql', version: 0}));
 				expect(result).to.be.null;
 		});
 
 		it('should return diagnostic when rule is enabled and pattern does not match - join', async () => {
 				instance.enabled = true;
 				const parser = new Parser();
-				const result = instance.evaluate(await parser.parse({text:'select *\n  from dataset.table a\n  left join other.table b\n    on a.id = b.id\n   and a.date = b.date\n where 1  = 1\n   and 10 = 1', uri: 'test.sql', languageId: 'sql', version: 0}));
+				const result = instance.evaluate(await parser.parse({text:'select *\n  from dataset.table a\n  left join other.table b\n    on a.id  = b.id\n   and a.date  = b.date\n where 1   = 1\n   and 10  = 1', uri: 'test.sql', languageId: 'sql', version: 0}));
 				expect(result).to.deep.equal([{
 						code: instance.diagnosticCode,
             codeDescription: {href: instance.diagnosticCodeDescription},
 						message: instance.message,
 						severity: instance.severity,
 						range: {
-								start: { line: 3, character: 12 },
+								start: { line: 3, character: 13 },
 								end: { line: 3, character: 13 }
-						},
-						source: instance.source
-				},
-				{
-						code: instance.diagnosticCode,
-            codeDescription: {href: instance.diagnosticCodeDescription},
-						message: instance.message,
-						severity: instance.severity,
-						range: {
-								start: { line: 4, character: 14 },
-								end: { line: 4, character: 15 }
 						},
 						source: instance.source
 				}]);
@@ -87,7 +76,7 @@ describe('ComparisonOperators', () => {
 		it('should return null when rule is enabled but pattern does not match - join', async () => {
 				instance.enabled = true;
 				const parser = new Parser();
-				const result = instance.evaluate(await parser.parse({text:'select *\n  from dataset.table a\n  left join other.table b\n    on a.id   = b.id\n   and a.date = b.date\n where 1  = 1\n   and 10 = 1', uri: 'test.sql', languageId: 'sql', version: 0}));
+				const result = instance.evaluate(await parser.parse({text:'select *\n  from dataset.table a\n  left join other.table b\n    on a.id    = b.id\n   and a.date  = b.date\n where 1   = 1\n   and 10  = 1', uri: 'test.sql', languageId: 'sql', version: 0}));
 				expect(result).to.be.null;
 		});
 });


### PR DESCRIPTION
This pull request refactors the indentation error handling in the base rule by moving the createIndentErrorOutputs method from the Indent class to the base Rule class. This change improves code organization and reusability. Additionally, the createIndentErrorOutputs method is updated to handle both positive and negative error offsets, allowing for more flexible error handling.