### PR TITLE
Add set operators rule CV12, refactor SpacesNotTabs to CV13

### DIFF
--- a/docs/source/rules/convention/CV12.rst
+++ b/docs/source/rules/convention/CV12.rst
@@ -1,58 +1,72 @@
-==========================================
-Rule: Use Spaces for Indentation, Not Tabs
-==========================================
+==================================================================
+Rule: `UNION` and `EXCEPT` Must Be Followed by `ALL` or `DISTINCT`
+==================================================================
 
 **Rule Code:** ``CV12``
 
-**Name:** ``spaces_not_tabs``
+**Name:** ``all_distinct``
 
 Overview
 --------
 
-In SQL and programming in general, it is a best practice to use spaces for indentation instead of tabs. While both spaces and tabs can be used to indent code, spaces provide more consistent formatting across different environments, editors, and systems. Using spaces for indentation ensures that the code appears the same regardless of the viewer’s settings and avoids issues with misaligned or uneven code that can result from the use of tabs.
+In BigQuery SQL, when using set operators such as `UNION` and `EXCEPT`, the query must explicitly specify whether `ALL` or `DISTINCT` should be applied. This ensures that the intent of the operation is clear, defining whether all rows are retained (`ALL`) or if duplicates are removed (`DISTINCT`). Failing to specify either `ALL` or `DISTINCT` results in invalid syntax. The requirement to use `ALL` or `DISTINCT` for `UNION` and `EXCEPT` helps clarify the behavior of the set operation and ensures that the query behaves consistently across different environments.
 
 Explanation
 -----------
 
-Anti-pattern: Using Tabs for Indentation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Anti-pattern: Omitting `ALL` or `DISTINCT` in Set Operators
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Using tabs for indentation can lead to inconsistent formatting because different editors and environments interpret tabs differently. A tab might be displayed as two, four, or even eight spaces depending on the configuration of the user's editor, making it difficult to maintain a consistent look and feel for the code. This can lead to confusion, especially when multiple developers work on the same codebase.
+When using `UNION` or `EXCEPT` without explicitly specifying `ALL` or `DISTINCT`, the query is invalid in BigQuery SQL. This ambiguity in the set operation can lead to confusion or unexpected behavior, as the result set will either retain all rows (`ALL`) or remove duplicates (`DISTINCT`) based on the set operator used. 
 
-**Example of Using Tabs for Indentation (Anti-pattern):**
-
-.. code-block:: sql
-
-    select *
-      from orders
-      join customers
-        on orders.customer_id = customers.id;
-
-In this example, tabs are used for indentation, which can result in inconsistent alignment depending on the viewer's editor settings.
-
-Best Practice: Use Spaces for Indentation
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-To ensure consistent formatting and readability across different environments, spaces should be used for indentation. Most coding standards recommend using spaces because they provide a uniform way of displaying indents, regardless of the editor settings.
-
-**Refactored Example Using Spaces for Indentation (Best Practice):**
+**Example of Invalid `UNION` or `EXCEPT` Without `ALL` or `DISTINCT` (Anti-pattern):**
 
 .. code-block:: sql
 
-    select *
-      from orders
-      join customers
-        on orders.customer_id = customers.id;
+    select col1
+      from table1
+    union
+    select col1
+      from table2;
 
-In this refactored example, spaces are used for indentation, ensuring that the code appears consistent across different editors and systems.
+In this example, the `UNION` operation is missing the required `ALL` or `DISTINCT` keyword, making the query invalid.
+
+Best Practice: Always Specify `ALL` or `DISTINCT` After Set Operators
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To ensure that the query is valid and behaves as expected, it is essential to explicitly specify `ALL` or `DISTINCT` after `UNION` and `EXCEPT`. This makes the intent of the query clear, defining whether the operation should retain all rows or remove duplicates.
+
+**Refactored Example with `ALL` Specified (Best Practice):**
+
+.. code-block:: sql
+
+    select col1
+      from table1
+    union all
+    select col1
+      from table2;
+
+In this refactored example, the `UNION ALL` operation is used to specify that all rows should be retained in the result set, ensuring the query is valid and the behavior is clear.
+
+**Refactored Example with `DISTINCT` Specified (Best Practice):**
+
+.. code-block:: sql
+
+    select col1
+      from table1
+    except distinct
+    select col1
+      from table2;
+
+In this example, `EXCEPT DISTINCT` is used to ensure that duplicates are removed from the result set, which clarifies the intent of the query.
 
 Conclusion
 ----------
 
-Using spaces for indentation instead of tabs ensures that SQL queries are consistently formatted, readable, and maintainable. This practice reduces the likelihood of formatting issues caused by different tab width settings in various editors and environments, leading to cleaner and more professional code.
+In BigQuery SQL, the `UNION` and `EXCEPT` set operators must be followed by `ALL` or `DISTINCT` to ensure clarity and correctness. Specifying `ALL` retains all rows, while `DISTINCT` removes duplicates. By following this rule, developers ensure that their queries are valid and behave consistently across different SQL environments.
 
 Groups:
 -------
 
-- ``all``
-- ``convention``
+- `all <../..>`_
+- `convention <../..#convention-rules>`_

--- a/docs/source/rules/convention/CV13.rst
+++ b/docs/source/rules/convention/CV13.rst
@@ -1,0 +1,58 @@
+==========================================
+Rule: Use Spaces for Indentation, Not Tabs
+==========================================
+
+**Rule Code:** ``CV13``
+
+**Name:** ``spaces_not_tabs``
+
+Overview
+--------
+
+In SQL and programming in general, it is a best practice to use spaces for indentation instead of tabs. While both spaces and tabs can be used to indent code, spaces provide more consistent formatting across different environments, editors, and systems. Using spaces for indentation ensures that the code appears the same regardless of the viewer’s settings and avoids issues with misaligned or uneven code that can result from the use of tabs.
+
+Explanation
+-----------
+
+Anti-pattern: Using Tabs for Indentation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Using tabs for indentation can lead to inconsistent formatting because different editors and environments interpret tabs differently. A tab might be displayed as two, four, or even eight spaces depending on the configuration of the user's editor, making it difficult to maintain a consistent look and feel for the code. This can lead to confusion, especially when multiple developers work on the same codebase.
+
+**Example of Using Tabs for Indentation (Anti-pattern):**
+
+.. code-block:: sql
+
+    select *
+      from orders
+      join customers
+        on orders.customer_id = customers.id;
+
+In this example, tabs are used for indentation, which can result in inconsistent alignment depending on the viewer's editor settings.
+
+Best Practice: Use Spaces for Indentation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To ensure consistent formatting and readability across different environments, spaces should be used for indentation. Most coding standards recommend using spaces because they provide a uniform way of displaying indents, regardless of the editor settings.
+
+**Refactored Example Using Spaces for Indentation (Best Practice):**
+
+.. code-block:: sql
+
+    select *
+      from orders
+      join customers
+        on orders.customer_id = customers.id;
+
+In this refactored example, spaces are used for indentation, ensuring that the code appears consistent across different editors and systems.
+
+Conclusion
+----------
+
+Using spaces for indentation instead of tabs ensures that SQL queries are consistently formatted, readable, and maintainable. This practice reduces the likelihood of formatting issues caused by different tab width settings in various editors and environments, leading to cleaner and more professional code.
+
+Groups:
+-------
+
+- `all <../..>`_
+- `convention <../..#convention-rules>`_

--- a/docs/source/rules/index.rst
+++ b/docs/source/rules/index.rst
@@ -64,10 +64,12 @@ By applying convention rules, teams can create a more collaborative and coherent
 
 	Rule: Use `!=` Not `<>` <convention/CV01>
 	Rule: Use COALESCE Instead of IFNULL or NVL <convention/CV02>
+	Rule: Select Statements Should Not Include a Trailing Comma <convention/CV03>
 	Rule: Use `count(1)` to Express “Count Number of Rows” <convention/CV04>
 	Rule: Comparisons with `NULL` Should Use `IS` or `IS NOT` <convention/CV05>
 	Rule: Use LEFT join Instead of RIGHT join <convention/CV08>
-	Rule: Use Spaces for Indentation, Not Tabs <convention/CV12>
+	Rule: `UNION` and `EXCEPT` Must Be Followed by `ALL` or `DISTINCT` <convention/CV12>
+	Rule: Use Spaces for Indentation, Not Tabs <convention/CV13>
 
 .. _layout-rules:
 

--- a/server/src/linter/rules/convention/CV12.ts
+++ b/server/src/linter/rules/convention/CV12.ts
@@ -1,30 +1,29 @@
 import { ServerSettings } from "../../../settings";
-import { CodeAction, CodeActionKind, Diagnostic, DiagnosticSeverity, TextDocumentIdentifier, TextEdit } from 'vscode-languageserver/node';
+import { Diagnostic, DiagnosticSeverity, TextDocumentIdentifier } from 'vscode-languageserver/node';
 import { Rule } from '../base';
 
 
 /**
- * The SpacesNotTabs rule
- * @class SpacesNotTabs
+ * The AllDistinct rule
+ * @class AllDistinct
  * @extends Rule
  * @memberof Linter.Rules
  */
-export class SpacesNotTabs extends Rule<string> {
-  readonly name: string = "spaces_not_tabs";
+export class AllDistinct extends Rule<string> {
+  readonly is_fix_compatible: boolean = false;
+  readonly name: string = "all_distinct";
   readonly code: string = "CV12";
-  readonly message: string = "Use spaces for indentation instead of tabs.";
-	readonly relatedInformation: string = "To ensure consistent formatting and readability across different environments, spaces should be used for indentation.";
-  readonly pattern: RegExp = /\t+/gmi;
+  readonly message: string = "Set operators require all|distinct";
+	readonly relatedInformation: string = "To ensure better readability and prevent errors, the trailing comma should be omitted in `SELECT` statements.";
+  readonly pattern: RegExp = /union\s+(?!all|distinct)|(?:except|intersect)\s+(?!distinct)/gmi;
   readonly severity: DiagnosticSeverity = DiagnosticSeverity.Warning;
   readonly ruleGroup: string = 'convention';
-  readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
-  readonly codeActionTitle = 'Replace with spaces';
 
   /**
-   * Creates an instance of SpacesNotTabs.
+   * Creates an instance of AllDistinct.
    * @param {ServerSettings} settings The server settings
    * @param {number} problems The number of problems identified in the source code
-   * @memberof SpacesNotTabs
+   * @memberof AllDistinct
    */
   constructor(settings: ServerSettings, problems: number) {
     super(settings, problems);
@@ -58,27 +57,5 @@ export class SpacesNotTabs extends Rule<string> {
    * @param diagnostic - The diagnostic information about the issue to be fixed.
    * @returns An array of code actions that can be applied to fix the issue.
    */
-  createCodeAction(textDocument: TextDocumentIdentifier, diagnostic: Diagnostic): CodeAction[] {
-    const count = diagnostic.range.end.character - diagnostic.range.start.character;
-    const edit = {
-        changes: {
-            [textDocument.uri]: [
-                TextEdit.replace(diagnostic.range, ' '.repeat(count * 2))
-            ]
-        }
-    };
-    const actions: CodeAction[] = [];
-    
-    this.codeActionKind.map((kind) => {
-      const fix = CodeAction.create(
-        this.codeActionTitle,
-        edit,
-        kind
-      );
-      fix.diagnostics = [diagnostic];
-      actions.push(fix);
-    });
-
-    return actions;
-  }
+  createCodeAction(textDocument: TextDocumentIdentifier, diagnostic: Diagnostic): null { return null; }
 }

--- a/server/src/linter/rules/convention/CV13.ts
+++ b/server/src/linter/rules/convention/CV13.ts
@@ -1,0 +1,84 @@
+import { ServerSettings } from "../../../settings";
+import { CodeAction, CodeActionKind, Diagnostic, DiagnosticSeverity, TextDocumentIdentifier, TextEdit } from 'vscode-languageserver/node';
+import { Rule } from '../base';
+
+
+/**
+ * The SpacesNotTabs rule
+ * @class SpacesNotTabs
+ * @extends Rule
+ * @memberof Linter.Rules
+ */
+export class SpacesNotTabs extends Rule<string> {
+  readonly name: string = "spaces_not_tabs";
+  readonly code: string = "CV13";
+  readonly message: string = "Use spaces for indentation instead of tabs.";
+	readonly relatedInformation: string = "To ensure consistent formatting and readability across different environments, spaces should be used for indentation.";
+  readonly pattern: RegExp = /\t+/gmi;
+  readonly severity: DiagnosticSeverity = DiagnosticSeverity.Warning;
+  readonly ruleGroup: string = 'convention';
+  readonly codeActionKind: CodeActionKind[] = [CodeActionKind.SourceFixAll, CodeActionKind.QuickFix];
+  readonly codeActionTitle = 'Replace with spaces';
+
+  /**
+   * Creates an instance of SpacesNotTabs.
+   * @param {ServerSettings} settings The server settings
+   * @param {number} problems The number of problems identified in the source code
+   * @memberof SpacesNotTabs
+   */
+  constructor(settings: ServerSettings, problems: number) {
+    super(settings, problems);
+  }
+
+  /**
+   * Evaluates the given test string against a pattern and returns diagnostics if the pattern matches.
+   *
+   * @param test - The string to be tested against the pattern.
+   * @param documentUri - The URI of the document being evaluated, optional.
+   * @returns An array of diagnostics if the pattern matches, otherwise null.
+   */
+  evaluate(test: string, documentUri: string | null = null): Diagnostic[] | null {
+
+    if (this.enabled === false) {
+      return null;
+    }
+
+    if (this.pattern.test(test)) {
+      return this.evaluateRegexPatterns(test, documentUri);
+    }
+
+    return null;
+
+  }
+  
+  /**
+   * Creates a set of code actions to fix diagnostics.
+   *
+   * @param textDocument - The identifier of the text document where the diagnostic was reported.
+   * @param diagnostic - The diagnostic information about the issue to be fixed.
+   * @returns An array of code actions that can be applied to fix the issue.
+   */
+  createCodeAction(textDocument: TextDocumentIdentifier, diagnostic: Diagnostic): CodeAction[] {
+    const count = diagnostic.range.end.character - diagnostic.range.start.character;
+    const edit = {
+        changes: {
+            [textDocument.uri]: [
+                TextEdit.replace(diagnostic.range, ' '.repeat(count * 2))
+            ]
+        }
+    };
+    const actions: CodeAction[] = [];
+    
+    this.codeActionKind.map((kind) => {
+      const fix = CodeAction.create(
+        this.codeActionTitle,
+        edit,
+        kind
+      );
+      fix.diagnostics = [diagnostic];
+      actions.push(fix);
+    });
+
+    return actions;
+  }
+}

--- a/server/src/linter/rules/convention/rules.ts
+++ b/server/src/linter/rules/convention/rules.ts
@@ -14,7 +14,8 @@ import { SelectTrailingComma } from './CV03';
 import { Count } from './CV04';
 import { IsNull } from './CV05';
 import { LeftJoin } from './CV08';
-import { SpacesNotTabs } from './CV12';
+import { AllDistinct } from './CV12';
+import { SpacesNotTabs } from './CV13';
 import { FileMap } from '../../parser';
 
 export const classes = [NotEqual,
@@ -23,6 +24,7 @@ export const classes = [NotEqual,
 												Count,
 												IsNull,
 												LeftJoin,
+												AllDistinct,
 												SpacesNotTabs
 											];
 

--- a/server/src/tests/linter/rules/convention/CV13.test.ts
+++ b/server/src/tests/linter/rules/convention/CV13.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @fileoverview Test suite for LT13 module
+ */
+
+import { expect } from 'chai';
+import { defaultSettings } from '../../../../settings';
+import { SpacesNotTabs } from '../../../../linter/rules/convention/CV13';
+import { Parser } from '../../../../linter/parser';
+
+describe('SpacesNotTabs', () => {
+    let instance: SpacesNotTabs;
+
+    beforeEach(() => {
+        instance = new SpacesNotTabs(defaultSettings, 0);
+    });
+
+    it('should return null when rule is disabled', () => {
+        instance.enabled = false;
+        const result = instance.evaluate('test');
+        expect(result).to.be.null;
+    });
+
+    it('should return diagnostic when rule is enabled and pattern matches', () => {
+        instance.enabled = true;
+        const result = instance.evaluate('select a.col,\tb.col from dataset.table a left join dataset.table b on a.col != b.col');
+        expect(result).to.deep.equal([{
+            code: instance.diagnosticCode,
+            codeDescription: {href: instance.diagnosticCodeDescription},
+            message: instance.message,
+            severity: instance.severity,
+            range: {
+                start: { line: 0, character: 13 },
+                end: { line: 0, character: 14 }
+            },
+            source: instance.source
+        }]);
+    });
+
+    it('should return codeaction when rule is enabled and as used', async () => {
+        instance.enabled = true;
+        const parser = new Parser();
+        await parser.parse({text:'select a.col,\tb.col from dataset.table a left join dataset.table b on a.col != b.col', uri: 'test.sql', languageId: 'sql', version: 0});
+        const diagnostics = instance.evaluate('select a.col,\tb.col from dataset.table a left join dataset.table b on a.col != b.col');
+        const actions = instance.createCodeAction({uri: 'test.sql'}, diagnostics![0]);
+        expect(actions).to.deep.equal(instance.codeActionKind.map(kind => {
+            return {
+                title: instance.codeActionTitle, edit:{
+                changes: {
+                        ['test.sql']: [
+                            {
+                                newText: '  ',
+                                range: {
+                                    start: { line: 0, character: 13 },
+                                    end: { line: 0, character: 14 }
+                                }
+                            }
+                        ]
+                    }
+                },
+                kind: kind,
+                diagnostics: diagnostics
+            };
+        }));
+    });
+
+    it('should return null when rule is enabled but pattern does not match', () => {
+        instance.enabled = true;
+        const result = instance.evaluate('select a.col, b.col from dataset.table a left join dataset.table b on a.col != b.col');
+        expect(result).to.be.null;
+    });
+});


### PR DESCRIPTION
This pull request adds a new rule, CV12, which enforces the use of `ALL` or `DISTINCT` after `UNION`, `EXCEPT`, or `INTERSECT` operators. It also refactors the existing SpacesNotTabs rule to CV13, which ensures that spaces are used for indentation instead of tabs. These changes improve code consistency and readability.

<!-- readthedocs-preview bigquerysqlformatter start -->
----
📚 Documentation preview 📚: https://bigquerysqlformatter--222.org.readthedocs.build/en/222/

<!-- readthedocs-preview bigquerysqlformatter end -->